### PR TITLE
fix: ZoomISO manually created output select button not selecting output

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -208,7 +208,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 	let CHOICES_OUTPUTS = []
 	// Change this to actual created output, get that with pulling
 	for (let index = 1; index < 10; index++) {
-		CHOICES_OUTPUTS.push({ id: index.toString(), label: `Output ${index}` })
+		CHOICES_OUTPUTS.push({ id: index, label: `Output ${index}` })
 	}
 
 	let userOption: any = {
@@ -247,7 +247,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 		type: 'dropdown',
 		label: 'Output',
 		id: 'output',
-		default: '1',
+		default: 1,
 		choices: CHOICES_OUTPUTS,
 	}
 
@@ -1150,13 +1150,15 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			name: 'Select output',
 			options: [outputOption],
 			callback: (action) => {
-				const outputNumber: number = parseInt(action.options.output as string)
+				const outputNumber: number = action.options.output as number;
 				const index = instance.ZoomClientDataObj.selectedOutputs.indexOf(outputNumber)
+				// instance.log('debug', `outputNumber: ${outputNumber} selectedOutputs: ${JSON.stringify(instance.ZoomClientDataObj.selectedOutputs)}`)
 				if (index > -1) {
 					instance.ZoomClientDataObj.selectedOutputs.splice(index, 1)
 				} else {
 					instance.ZoomClientDataObj.selectedOutputs.push(outputNumber)
 				}
+				// instance.log('debug', `outputNumber: ${outputNumber} selectedOutputs: ${JSON.stringify(instance.ZoomClientDataObj.selectedOutputs)}`)
 				instance.checkFeedbacks(FeedbackId.output)
 			},
 		},

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1150,11 +1150,12 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			name: 'Select output',
 			options: [outputOption],
 			callback: (action) => {
-				const index = instance.ZoomClientDataObj.selectedOutputs.indexOf(action.options.output as number)
+				const outputNumber: number = parseInt(action.options.output as string)
+				const index = instance.ZoomClientDataObj.selectedOutputs.indexOf(outputNumber)
 				if (index > -1) {
 					instance.ZoomClientDataObj.selectedOutputs.splice(index, 1)
 				} else {
-					instance.ZoomClientDataObj.selectedOutputs.push(action.options.output as number)
+					instance.ZoomClientDataObj.selectedOutputs.push(outputNumber)
 				}
 				instance.checkFeedbacks(FeedbackId.output)
 			},

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1016,7 +1016,7 @@ export function GetPresetList(
 		steps: [{ down: [{ actionId: ActionId.applyChannel, options: {} }], up: [] }],
 		feedbacks: [],
 	}
-	for (let index = 1; index < 8; index++) {
+	for (let index = 1; index < 9; index++) {
 		presets[`Select_Output_${index}`] = {
 			type: 'button',
 			category: 'ZoomISO Output Actions',
@@ -1052,7 +1052,7 @@ export function GetPresetList(
 			],
 		}
 	}
-	for (let index = 1; index < 8; index++) {
+	for (let index = 1; index < 9; index++) {
 		presets[`Select_Audio_Channel ${index}`] = {
 			type: 'button',
 			category: 'ZoomISO Output Actions',


### PR DESCRIPTION
## Current Observed Behavior:

For the preset buttons select output buttons they selected the output as expected.  However, if you create a regular button and put the action to select action or if you copy one of the presets and pick a different output from the action output dropdown, it would not select the output.

The help for the module also says that 8 select output presets should be available but only 7 were available.

## Expected Behavior

The select output action and feedback work for both preset buttons and manually created buttons.  

there should be 8 select output and select audio output preset buttons

## Steps to Reproduce

1. Create a new button from one of the ZoomISO Select Output buttons
1. Click on the new button and see that it works to select the button and the feedback turns the button red
1. Change the action output to a different output and update the feedback for the same output
1. Click on the button again and notice that the output is not selected or at least the button indicates it is not selected

## Workaround

None

## Root Cause

The output selection dropdown button was setting the value as a string instead of a number where as the preset buttons were setting the value as a number.  This made the selected outputs array looks like [1,2,"8"] where "8" was the manually created button and the feedback was looking for the output number to be a number not a string.  This cause the output feedback to not think that output 8 was selected.  The code was doing an "as number" check but this doesn't actually make the conversion from a string to a number.

## Resolution

Updated the output dropdown to have the value as a number.

Update the loop that created the presets to be < 9 instead of < 8.