### PR TITLE
update: spotlight and clear participants button and action text

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -977,7 +977,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			},
 		},
 		[ActionId.clearParticipants]: {
-			name: 'Clear Participants',
+			name: 'Clear Selections',
 			options: [],
 			callback: () => {
 				instance.ZoomClientDataObj.selectedCallers.length = 0
@@ -1417,8 +1417,8 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			},
 		},
 		[ActionId.spotLight]: {
-			name: 'Spotlight',
-			options: [options.userName],
+			name: 'Single Spotlight',
+			options: [options.singleUserName],
 			callback: (action): void => {
 				// type: 'User'
 				let command = createCommand('/spot', action.options.userName, select.single)

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -185,9 +185,9 @@ export function GetPresetList(
 	presets[`Clear_Participants`] = {
 		type: 'button',
 		category: 'Manage Selections of Participants',
-		name: `Clear Participants`,
+		name: `Clear Selections`,
 		style: {
-			text: `Clear Participants ($(zoomosc:selectedNumberOfCallers))`,
+			text: `Clear Selections ($(zoomosc:selectedNumberOfCallers))`,
 			size: '14',
 			color: combineRgb(0, 0, 0),
 			bgcolor: combineRgb(230, 230, 230),
@@ -638,7 +638,7 @@ export function GetPresetList(
 		category: 'Pin/Spotlight & View Actions',
 		name: 'Spotlight',
 		style: {
-			text: 'Spotlight',
+			text: 'Single Spotlight',
 			size: '14',
 			color: combineRgb(0, 0, 0),
 			bgcolor: combineRgb(230, 230, 230),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,6 +123,7 @@ export interface Options {
 	zak: EnforceDefault<CompanionInputFieldTextInput, string>
 	name: EnforceDefault<CompanionInputFieldTextInput, string>
 	breakoutName: EnforceDefault<CompanionInputFieldTextInput, string>
+	singleUserName: EnforceDefault<CompanionInputFieldTextInput, string>
 	userName: EnforceDefault<CompanionInputFieldTextInput, string>
 	meetingID: EnforceDefault<CompanionInputFieldTextInput, string>
 	path: EnforceDefault<CompanionInputFieldTextInput, string>
@@ -213,6 +214,12 @@ export const options: Options = {
 		default: 1,
 		min: 1,
 		max: 256,
+	},
+	singleUserName: {
+		type: 'textinput',
+		label: 'single username (keep blank when you pre-select)',
+		id: 'userName',
+		default: '',
 	},
 	userName: {
 		type: 'textinput',


### PR DESCRIPTION
per the discussion with @AndrewCarluccio on the presentation on Spotlight and Clear Participants, I changed the button text to  Single Spotlight and Clear Selection and updated the Single Spotlight text above the input field for username.

![image](https://user-images.githubusercontent.com/708423/216801990-a3e1df28-cb05-4b30-b527-ea63bb4eebc4.png)


![image](https://user-images.githubusercontent.com/708423/216802006-ec98dba2-5f26-43d8-af32-f7895e472246.png)
