### PR TITLE
fix: feedback advanced names

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -796,7 +796,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 					instance.config.selectionMethod = action.options.selectionMethod as number
 				}
 				instance.saveConfig(instance.config)
-				instance.checkFeedbacks(FeedbackId.selectionMethod, FeedbackId.groupBased)
+				instance.checkFeedbacks(FeedbackId.selectionMethod, FeedbackId.groupBased, FeedbackId.groupBasedAdvanced)
 			},
 		},
 		[ActionId.selectUser]: {
@@ -840,10 +840,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				}
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.indexBased,
-					FeedbackId.groupBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -892,10 +896,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 							}
 							instance.UpdateVariablesValues()
 							instance.checkFeedbacks(
-								FeedbackId.groupBased,
-								FeedbackId.indexBased,
 								FeedbackId.userNameBased,
-								FeedbackId.galleryBased
+								FeedbackId.userNameBasedAdvanced,
+								FeedbackId.indexBased,
+								FeedbackId.indexBasedAdvanced,
+								FeedbackId.galleryBased,
+								FeedbackId.galleryBasedAdvanced,
+								FeedbackId.groupBased,
+								FeedbackId.groupBasedAdvanced
 							)
 
 							break
@@ -915,10 +923,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				})
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -964,10 +976,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				}
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1012,10 +1028,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				}
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1059,10 +1079,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				}
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1074,10 +1098,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				instance.ZoomClientDataObj.selectedCallers.length = 0
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1088,10 +1116,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				PreviousSelectedCallersRestore()
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1135,10 +1167,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				// instance.ZoomClientDataObj.selectedCallers.length = 0
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1148,7 +1184,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			callback: (action) => {
 				instance.ZoomGroupData[action.options.group as number].users.length = 0
 				instance.UpdateVariablesValues()
-				instance.checkFeedbacks(FeedbackId.groupBased)
+				instance.checkFeedbacks(FeedbackId.groupBased, FeedbackId.groupBasedAdvanced)
 			},
 		},
 		[ActionId.removeFromGroup]: {
@@ -1196,7 +1232,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 					PreviousSelectedCallersSave()
 					// instance.ZoomClientDataObj.selectedCallers.length = 0
 					instance.UpdateVariablesValues()
-					instance.checkFeedbacks(FeedbackId.groupBased)
+					instance.checkFeedbacks(FeedbackId.groupBased, FeedbackId.groupBasedAdvanced)
 				} else {
 					instance.log('debug', 'No correct group selected')
 				}
@@ -1270,10 +1306,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1300,10 +1340,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1322,10 +1366,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
-					FeedbackId.galleryBased
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},
@@ -1381,10 +1429,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 					// instance.ZoomClientDataObj.selectedOutputs.length = 0
 					instance.UpdateVariablesValues()
 					instance.checkFeedbacks(
-						FeedbackId.groupBased,
-						FeedbackId.indexBased,
 						FeedbackId.userNameBased,
+						FeedbackId.userNameBasedAdvanced,
+						FeedbackId.indexBased,
+						FeedbackId.indexBasedAdvanced,
 						FeedbackId.galleryBased,
+						FeedbackId.galleryBasedAdvanced,
+						FeedbackId.groupBased,
+						FeedbackId.groupBasedAdvanced,
 						FeedbackId.output
 					)
 				}
@@ -1412,10 +1464,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 					// instance.ZoomClientDataObj.selectedOutputs.length = 0
 					instance.UpdateVariablesValues()
 					instance.checkFeedbacks(
-						FeedbackId.groupBased,
-						FeedbackId.indexBased,
 						FeedbackId.userNameBased,
+						FeedbackId.userNameBasedAdvanced,
+						FeedbackId.indexBased,
+						FeedbackId.indexBasedAdvanced,
 						FeedbackId.galleryBased,
+						FeedbackId.galleryBasedAdvanced,
+						FeedbackId.groupBased,
+						FeedbackId.groupBasedAdvanced,
 						FeedbackId.output
 					)
 				}
@@ -1450,10 +1506,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 				// instance.ZoomClientDataObj.selectedOutputs.length = 0
 				instance.UpdateVariablesValues()
 				instance.checkFeedbacks(
-					FeedbackId.groupBased,
-					FeedbackId.indexBased,
 					FeedbackId.userNameBased,
+					FeedbackId.userNameBasedAdvanced,
+					FeedbackId.indexBased,
+					FeedbackId.indexBasedAdvanced,
 					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced,
 					FeedbackId.output
 				)
 			},
@@ -2721,10 +2781,14 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 					}
 				}
 				instance.checkFeedbacks(
-					FeedbackId.galleryBased,
-					FeedbackId.groupBased,
+					FeedbackId.userNameBased,
+					FeedbackId.userNameBasedAdvanced,
 					FeedbackId.indexBased,
-					FeedbackId.userNameBased
+					FeedbackId.indexBasedAdvanced,
+					FeedbackId.galleryBased,
+					FeedbackId.galleryBasedAdvanced,
+					FeedbackId.groupBased,
+					FeedbackId.groupBasedAdvanced
 				)
 			},
 		},

--- a/src/feedback-state-machine.ts
+++ b/src/feedback-state-machine.ts
@@ -141,6 +141,7 @@ export function feedbackResultsAdvanced(
 	if (userExist(zoomID, instance.ZoomUserData)) {
 		const participantState = getParticipantState(instance, zoomID)
 		const stateIndex = stateMachine.states.findIndex((state) => state.toString() === participantState.toString())
+
 		const image = getImageForState(
 			stateMachine.states[stateIndex],
 			instance.config.feedbackImagesWithIcons !== undefined ? instance.config.feedbackImagesWithIcons : 1

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -12,8 +12,8 @@ export enum FeedbackId {
 	selectionMethod = 'selection_Method',
 	groupBased = 'group_Based',
 	groupBasedAdvanced = 'group_Based_Advanced',
-	indexBased = 'index_Based_Advanced',
-	indexBasedAdvanced = 'index_Based',
+	indexBased = 'index_Based',
+	indexBasedAdvanced = 'index_Based_Advanced',
 	galleryBased = 'gallery_Based',
 	galleryBasedAdvanced = 'gallery_Based_Advanced',
 	userNameBased = 'user_Name_Based',
@@ -185,7 +185,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 		},
 		[FeedbackId.groupBasedAdvanced]: {
 			type: 'advanced',
-			name: 'Group based feedback',
+			name: 'Group based feedback (advanced)',
 			description: 'Position 1 - 999',
 			options: [
 				{
@@ -260,7 +260,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 		},
 		[FeedbackId.indexBasedAdvanced]: {
 			type: 'advanced',
-			name: 'Participant position based feedback',
+			name: 'Participant position based feedback (advanced)',
 			description: 'Feedback based on index of the participant',
 			options: [
 				{
@@ -328,7 +328,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 		},
 		[FeedbackId.userNameBasedAdvanced]: {
 			type: 'advanced',
-			name: 'Username based feedback Advanced',
+			name: 'Username based feedback (advanced)',
 			description: 'type in username',
 			options: [
 				{
@@ -398,7 +398,7 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 		},
 		[FeedbackId.galleryBasedAdvanced]: {
 			type: 'advanced',
-			name: 'Gallery based feedback Advanced',
+			name: 'Gallery based feedback (advanced)',
 			description: 'Position 1 - 49',
 			options: [
 				{

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -224,9 +224,13 @@ export class OSC {
 								this.instance.UpdateVariablesValues()
 								this.instance.checkFeedbacks(
 									FeedbackId.userNameBased,
+									FeedbackId.userNameBasedAdvanced,
 									FeedbackId.indexBased,
+									FeedbackId.indexBasedAdvanced,
 									FeedbackId.galleryBased,
-									FeedbackId.groupBased
+									FeedbackId.galleryBasedAdvanced,
+									FeedbackId.groupBased,
+									FeedbackId.groupBasedAdvanced
 								)
 							}
 							break
@@ -234,42 +238,96 @@ export class OSC {
 							if (userExist(zoomId, this.instance.ZoomUserData)) {
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))
 								this.instance.ZoomUserData[zoomId].videoOn = true
-								this.instance.checkFeedbacks(FeedbackId.indexBased, FeedbackId.galleryBased, FeedbackId.groupBased)
+								this.instance.checkFeedbacks(
+									FeedbackId.userNameBased,
+									FeedbackId.userNameBasedAdvanced,
+									FeedbackId.indexBased,
+									FeedbackId.indexBasedAdvanced,
+									FeedbackId.galleryBased,
+									FeedbackId.galleryBasedAdvanced,
+									FeedbackId.groupBased,
+									FeedbackId.groupBasedAdvanced
+								)
 							}
 							break
 						case 'videoOff':
 							this.instance.log('info', 'receiving:' + JSON.stringify(data))
 							if (userExist(zoomId, this.instance.ZoomUserData)) {
 								this.instance.ZoomUserData[zoomId].videoOn = false
-								this.instance.checkFeedbacks(FeedbackId.indexBased, FeedbackId.galleryBased, FeedbackId.groupBased)
+								this.instance.checkFeedbacks(
+									FeedbackId.userNameBased,
+									FeedbackId.userNameBasedAdvanced,
+									FeedbackId.indexBased,
+									FeedbackId.indexBasedAdvanced,
+									FeedbackId.galleryBased,
+									FeedbackId.galleryBasedAdvanced,
+									FeedbackId.groupBased,
+									FeedbackId.groupBasedAdvanced
+								)
 							}
 							break
 						case 'mute':
 							if (userExist(zoomId, this.instance.ZoomUserData)) {
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))
 								this.instance.ZoomUserData[zoomId].mute = true
-								this.instance.checkFeedbacks(FeedbackId.indexBased, FeedbackId.galleryBased, FeedbackId.groupBased)
+								this.instance.checkFeedbacks(
+									FeedbackId.userNameBased,
+									FeedbackId.userNameBasedAdvanced,
+									FeedbackId.indexBased,
+									FeedbackId.indexBasedAdvanced,
+									FeedbackId.galleryBased,
+									FeedbackId.galleryBasedAdvanced,
+									FeedbackId.groupBased,
+									FeedbackId.groupBasedAdvanced
+								)
 							}
 							break
 						case 'unMute':
 							if (userExist(zoomId, this.instance.ZoomUserData)) {
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))
 								this.instance.ZoomUserData[zoomId].mute = false
-								this.instance.checkFeedbacks(FeedbackId.indexBased, FeedbackId.galleryBased, FeedbackId.groupBased)
+								this.instance.checkFeedbacks(
+									FeedbackId.userNameBased,
+									FeedbackId.userNameBasedAdvanced,
+									FeedbackId.indexBased,
+									FeedbackId.indexBasedAdvanced,
+									FeedbackId.galleryBased,
+									FeedbackId.galleryBasedAdvanced,
+									FeedbackId.groupBased,
+									FeedbackId.groupBasedAdvanced
+								)
 							}
 							break
 						case 'handRaised':
 							if (userExist(zoomId, this.instance.ZoomUserData)) {
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))
 								this.instance.ZoomUserData[zoomId].handRaised = true
-								this.instance.checkFeedbacks(FeedbackId.indexBased, FeedbackId.galleryBased, FeedbackId.groupBased)
+								this.instance.checkFeedbacks(
+									FeedbackId.userNameBased,
+									FeedbackId.userNameBasedAdvanced,
+									FeedbackId.indexBased,
+									FeedbackId.indexBasedAdvanced,
+									FeedbackId.galleryBased,
+									FeedbackId.galleryBasedAdvanced,
+									FeedbackId.groupBased,
+									FeedbackId.groupBasedAdvanced
+								)
 							}
 							break
 						case 'handLowered':
 							if (userExist(zoomId, this.instance.ZoomUserData)) {
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))
 								this.instance.ZoomUserData[zoomId].handRaised = false
-								this.instance.checkFeedbacks(FeedbackId.indexBased, FeedbackId.galleryBased, FeedbackId.groupBased)
+								this.instance.checkFeedbacks(
+									FeedbackId.userNameBased,
+									FeedbackId.userNameBasedAdvanced,
+									FeedbackId.indexBased,
+									FeedbackId.indexBasedAdvanced,
+									FeedbackId.galleryBased,
+									FeedbackId.galleryBasedAdvanced,
+									FeedbackId.groupBased,
+									FeedbackId.groupBasedAdvanced
+								)
 							}
 							break
 						case 'online':
@@ -333,7 +391,7 @@ export class OSC {
 								)
 								if (index > -1) {
 									this.instance.ZoomGroupData[0].users.splice(index, 1)
-									this.instance.checkFeedbacks(FeedbackId.groupBased)
+									this.instance.checkFeedbacks(FeedbackId.groupBased, FeedbackId.groupBasedAdvanced)
 									this.updateLoop = true
 								}
 							} else if (data.args[4].value === UserRole.Host || data.args[4].value === UserRole.CoHost) {
@@ -346,7 +404,7 @@ export class OSC {
 										userName: data.args[1].value,
 									})
 									this.instance.log('debug', `added host: ${data.args[1].value}`)
-									this.instance.checkFeedbacks(FeedbackId.groupBased)
+									this.instance.checkFeedbacks(FeedbackId.groupBased, FeedbackId.groupBasedAdvanced)
 								}
 								this.updateLoop = true
 							}
@@ -378,7 +436,14 @@ export class OSC {
 					})
 					this.instance.InitVariables()
 					this.instance.UpdateVariablesValues()
-					this.instance.checkFeedbacks(FeedbackId.indexBased, FeedbackId.galleryBased, FeedbackId.groupBased)
+					this.instance.checkFeedbacks(
+						FeedbackId.indexBased,
+						FeedbackId.indexBasedAdvanced,
+						FeedbackId.galleryBased,
+						FeedbackId.galleryBasedAdvanced,
+						FeedbackId.groupBased,
+						FeedbackId.groupBasedAdvanced
+					)
 					break
 
 				case 'galleryCount':


### PR DESCRIPTION
- fix: index based was pointing to the advanced feedback
- fix: index based advanced was pointing to the old feedback
- fix: advanced names did not have the word advanced in the name so it looked like there were duplicate feedback actions in the list.  Now the advanced feedbacks will have (advanced) in the name

fixes: #123 