### PR TITLE
fix: participant action undefined

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -39,6 +39,7 @@ import {
 } from './actions/action-zoomiso-output-settings'
 import { ActionIdZoomISORouting, GetActionsZoomISORouting } from './actions/action-zoomiso-routing'
 import { ActionIdZoomISOActions, GetActionsZoomISOActions } from './actions/action-zoomiso-actions'
+import { ActionIdUsers, GetActionsUsers } from './actions/action-user'
 
 export enum ActionId {
 	loadISOConfig = 'load_ISO_Config',
@@ -127,6 +128,8 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 	const actionZoomISOActions: { [id in ActionIdZoomISOActions]: CompanionActionDefinition | undefined } =
 		GetActionsZoomISOActions(instance)
 
+	const actionUsers: { [id in ActionIdUsers]: CompanionActionDefinition | undefined } = GetActionsUsers(instance)
+
 	const actions: {
 		[id in
 			| ActionId
@@ -153,6 +156,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			| ActionIdZoomISOEngine
 			| ActionIdZoomISOOutputSettings
 			| ActionIdZoomISOActions
+			| ActionIdUsers
 			| ActionIdZoomISORouting]: CompanionActionDefinition | undefined
 	} = {
 		...actionsGroups,
@@ -179,7 +183,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 		...actionZoomISOEngine,
 		...actionZoomISOOutputSettings,
 		...actionZoomISOActions,
-
+		...actionUsers,
 		[ActionId.loadISOConfig]: {
 			name: 'Load Config',
 			options: [options.path],

--- a/src/actions/action-user.ts
+++ b/src/actions/action-user.ts
@@ -4,7 +4,6 @@ import { InstanceBaseExt, arrayAdd, arrayRemove, options, userExist } from '../u
 import { FeedbackId } from '../feedback'
 import {
 	selectionMethod,
-	userOption,
 	PreviousSelectedCallersSave,
 	toggleSelectedUser,
 	PreviousSelectedCallersRestore,
@@ -12,7 +11,6 @@ import {
 
 export enum ActionIdUsers {
 	selectionMethod = 'selection_Method',
-	selectUser = 'select_User',
 	selectUserByName = 'select_User_By_Name',
 	selectFromIndexPosition = 'select_From_Index_Position',
 	clearParticipants = 'clear_Participants',
@@ -69,58 +67,6 @@ export function GetActionsUsers(instance: InstanceBaseExt<ZoomConfig>): {
 				}
 				instance.saveConfig(instance.config)
 				instance.checkFeedbacks(FeedbackId.selectionMethod, FeedbackId.groupBased, FeedbackId.groupBasedAdvanced)
-			},
-		},
-		[ActionIdUsers.selectUser]: {
-			name: 'Preselect user',
-			options: [
-				userOption,
-				{
-					type: 'dropdown',
-					label: 'Option',
-					id: 'option',
-					default: '',
-					choices: [
-						{ label: 'Toggle', id: 'toggle' },
-						{ label: 'Select', id: 'select' },
-						{ label: 'Remove', id: 'remove' },
-					],
-				},
-			],
-			callback: (action) => {
-				PreviousSelectedCallersSave(instance)
-				switch (action.options.option) {
-					case 'toggle':
-						instance.ZoomClientDataObj.PreviousSelectedCallers = instance.ZoomClientDataObj.selectedCallers
-						toggleSelectedUser(instance, action.options.user as number)
-						break
-					case 'select':
-						if (instance.config.selectionMethod === selectionMethod.SingleSelection) {
-							instance.ZoomClientDataObj.selectedCallers.length = 0
-						}
-						instance.ZoomClientDataObj.selectedCallers = arrayAdd(
-							instance.ZoomClientDataObj.selectedCallers,
-							action.options.user as number
-						)
-						break
-					case 'remove':
-						instance.ZoomClientDataObj.selectedCallers = arrayRemove(
-							instance.ZoomClientDataObj.selectedCallers,
-							action.options.user as number
-						)
-						break
-				}
-				instance.UpdateVariablesValues()
-				instance.checkFeedbacks(
-					FeedbackId.userNameBased,
-					FeedbackId.userNameBasedAdvanced,
-					FeedbackId.indexBased,
-					FeedbackId.indexBasedAdvanced,
-					FeedbackId.galleryBased,
-					FeedbackId.galleryBasedAdvanced,
-					FeedbackId.groupBased,
-					FeedbackId.groupBasedAdvanced
-				)
 			},
 		},
 		[ActionIdUsers.selectUserByName]: {

--- a/src/actions/action-utils.ts
+++ b/src/actions/action-utils.ts
@@ -1,6 +1,6 @@
 import { CompanionActionEvent, InputValue, SomeCompanionActionInputField } from '@companion-module/base'
 import { ZoomConfig } from '../config'
-import { InstanceBaseExt, arrayAdd, arrayAddRemove, arrayRemove, userExist } from '../utils'
+import { InstanceBaseExt, arrayAdd, arrayAddRemove, arrayRemove } from '../utils'
 
 export const select = { single: true, multi: false }
 
@@ -26,31 +26,6 @@ export const positionOrderOption: SomeCompanionActionInputField = {
 	choices: CHOICES_POSITION,
 }
 
-let CHOICES_USERS_DEFAULT = '0'
-const CHOICES_USERS: {
-	id: string
-	label: string
-}[] = [{ id: '0', label: 'no users' }]
-
-export const getChoiceUsers = (instance: InstanceBaseExt<ZoomConfig>): void => {
-	if (instance.ZoomUserData) {
-		CHOICES_USERS.length = 0
-		for (const key in instance.ZoomUserData) {
-			if (userExist(Number(key), instance.ZoomUserData)) {
-				const user = instance.ZoomUserData[key]
-				CHOICES_USERS.push({ id: user.zoomId.toString(), label: user.userName })
-				CHOICES_USERS_DEFAULT = user.zoomId.toString()
-			}
-		}
-	}
-}
-export const userOption: any = {
-	type: 'dropdown',
-	label: 'User',
-	id: 'user',
-	default: CHOICES_USERS_DEFAULT,
-	choices: CHOICES_USERS,
-}
 export enum selectionMethod {
 	SingleSelection = 1,
 	MultiSelection = 0,

--- a/src/presets/preset-reaction-name.ts
+++ b/src/presets/preset-reaction-name.ts
@@ -115,7 +115,7 @@ export function GetPresetsReactionName(ZoomUserData: ZoomUserDataInterface): Com
 				name: user.userName,
 				style: {
 					text: `Rename\\n$(zoomosc:${user.zoomId})`,
-					size: '14',
+					size: '7',
 					color: colorBlack,
 					bgcolor: colorTeal,
 				},

--- a/src/presets/preset-utils.ts
+++ b/src/presets/preset-utils.ts
@@ -117,7 +117,7 @@ export const getFeedbackStyleSelected = (): CompanionFeedbackButtonStyleResult =
 
 export const getParticipantStyleDefault = (text: string, position: number): CompanionButtonStyleProps => {
 	return {
-		text: `\\n${position}. ${text})`,
+		text: `\\n${position}. ${text}`,
 		size: '7',
 		color: colorWhite,
 		bgcolor: colorBlack,

--- a/src/v2CommandsToUpgradeTov3.ts
+++ b/src/v2CommandsToUpgradeTov3.ts
@@ -753,7 +753,7 @@ export const v2Actions: v2Action = {
 	},
 	SelectUser: {
 		oldActionId: 'SelectUser',
-		newActionId: ActionIdUsers.selectUser,
+		newActionId: ActionIdUserRolesAndAction.selectUser,
 		type: 'OtherActions',
 	},
 	SelectUserByName: {


### PR DESCRIPTION
when I split the actions and presets, the actions in the action-user.ts file were not included in the list of actions.  This caused the participant presets and the participant actions to no longer work.  This PR add the action-users.ts into the list of actions.

I also moved the select user into the action-user-roles-action.ts in an attempt to get the Rename preset buttons to consistently be created.  I noticed that several times my Zoom data was empty when the preset was created so the rename preset did not get created.  The action still works though and had the user list populated.