### PR TITLE
new feature: Auto create a group of all spotlighted users 

### DIFF
--- a/src/actions/action-global-gallery-tracking-and-data-request.ts
+++ b/src/actions/action-global-gallery-tracking-and-data-request.ts
@@ -6,6 +6,7 @@ import { createCommand, sendActionCommand } from './action-utils'
 export enum ActionIdGlobalGalleryTrackingAndDataRequest {
 	requestOrderOfGalleryView = 'requestOrderOfGalleryView',
 	requestGalleryCount = 'requestGalleryCount',
+	requestOrderOfSpotlights = 'requestOrderOfSpotlights',
 }
 
 export function GetActionsGlobalGalleryTrackingAndDataRequest(instance: InstanceBaseExt<ZoomConfig>): {
@@ -36,6 +37,22 @@ export function GetActionsGlobalGalleryTrackingAndDataRequest(instance: Instance
 				const command = createCommand(instance, '/galCount')
 				const sendToCommand = {
 					id: ActionIdGlobalGalleryTrackingAndDataRequest.requestGalleryCount,
+					options: {
+						command: command.oscPath,
+						args: command.args,
+					},
+				}
+				sendActionCommand(instance, sendToCommand)
+			},
+		},
+		[ActionIdGlobalGalleryTrackingAndDataRequest.requestOrderOfSpotlights]: {
+			name: 'Request Order Of Spotlights',
+			options: [],
+			callback: (): void => {
+				// type: 'Special'
+				const command = createCommand(instance, '/getSpotOrder')
+				const sendToCommand = {
+					id: ActionIdGlobalGalleryTrackingAndDataRequest.requestOrderOfSpotlights,
 					options: {
 						command: command.oscPath,
 						args: command.args,

--- a/src/actions/action-group.ts
+++ b/src/actions/action-group.ts
@@ -26,7 +26,7 @@ export function GetActionsGroups(instance: InstanceBaseExt<ZoomConfig>): {
 
 	instance.ZoomGroupData.forEach((group: { groupName: any }, index: { toString: () => any }) => {
 		CHOICES_GROUPS.push({ id: index.toString(), label: group.groupName })
-		if (index != 0) CHOICES_GROUPS_NO_HOST.push({ id: index.toString(), label: group.groupName })
+		if (index != 0 && index !== 1) CHOICES_GROUPS_NO_HOST.push({ id: index.toString(), label: group.groupName })
 	})
 
 	const groupOption: SomeCompanionActionInputField = {

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -32,6 +32,8 @@ export enum feedbackType {
 	micOff = 5,
 	handLowered = 6,
 	cameraOff = 7,
+	spotlightOn = 8,
+	spotlightOff = 9,
 }
 
 export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFeedbackDefinitions {
@@ -46,6 +48,18 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 		}
 
 		switch (type) {
+			case feedbackType.spotlightOn:
+				if (userExist(zoomID, instance.ZoomUserData)) {
+					return instance.ZoomUserData[zoomID].spotlighted === true
+				}
+
+				return false
+			case feedbackType.spotlightOff:
+				if (userExist(zoomID, instance.ZoomUserData)) {
+					return instance.ZoomUserData[zoomID].spotlighted === false
+				}
+
+				return false
 			case feedbackType.micLive:
 				if (userExist(zoomID, instance.ZoomUserData)) {
 					return instance.ZoomUserData[zoomID].mute === false
@@ -165,6 +179,8 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 						{ id: feedbackType.handLowered, label: 'Hand Lowered' },
 						{ id: feedbackType.cameraOff, label: 'Camera Off' },
 						{ id: feedbackType.activeSpeaker, label: 'Active Speaker' },
+						{ id: feedbackType.spotlightOn, label: 'Spotlight On' },
+						{ id: feedbackType.spotlightOff, label: 'Spotlight Off' },
 					],
 				},
 			],
@@ -241,6 +257,8 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 						{ id: feedbackType.handLowered, label: 'Hand Lowered' },
 						{ id: feedbackType.cameraOff, label: 'Camera Off' },
 						{ id: feedbackType.activeSpeaker, label: 'Active Speaker' },
+						{ id: feedbackType.spotlightOn, label: 'Spotlight On' },
+						{ id: feedbackType.spotlightOff, label: 'Spotlight Off' },
 					],
 				},
 			],
@@ -305,6 +323,8 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 						{ id: feedbackType.handLowered, label: 'Hand Lowered' },
 						{ id: feedbackType.cameraOff, label: 'Camera Off' },
 						{ id: feedbackType.activeSpeaker, label: 'Active Speaker' },
+						{ id: feedbackType.spotlightOn, label: 'Spotlight On' },
+						{ id: feedbackType.spotlightOff, label: 'Spotlight Off' },
 					],
 				},
 			],
@@ -381,6 +401,8 @@ export function GetFeedbacks(instance: InstanceBaseExt<ZoomConfig>): CompanionFe
 						{ id: feedbackType.handLowered, label: 'Hand Lowered' },
 						{ id: feedbackType.cameraOff, label: 'Camera Off' },
 						{ id: feedbackType.activeSpeaker, label: 'Active Speaker' },
+						{ id: feedbackType.spotlightOn, label: 'Spotlight On' },
+						{ id: feedbackType.spotlightOff, label: 'Spotlight Off' },
 					],
 				},
 			],

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,9 @@ class ZoomInstance extends InstanceBase<ZoomConfig> {
 		if (config.numberOfGroups !== this.ZoomClientDataObj.numberOfGroups)
 			this.ZoomClientDataObj.numberOfGroups = config.numberOfGroups
 
-		for (let index = 0; index < this.ZoomClientDataObj.numberOfGroups + 1; index++) {
+		for (let index = 0; index < this.ZoomClientDataObj.numberOfGroups + 2; index++) {
 			this.ZoomGroupData[index] = {
-				groupName: index === 0 ? 'Hosts' : `Group ${index}`,
+				groupName: index === 0 ? 'Hosts' : index === 1 ? 'Spotlights' : `Group ${index}`,
 				users: [],
 			}
 		}

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -569,6 +569,7 @@ export class OSC {
 				case 'spotOrder':
 					this.instance.ZoomGroupData[1].users.length = 0
 					data.args.forEach((order: { type: string; value: number }) => {
+						this.instance.ZoomUserData[order.value].spotlighted = true
 						const findIndex = this.instance.ZoomVariableLink.findIndex(
 							(id: { zoomId: number }) => id.zoomId === order.value
 						)

--- a/src/presets/preset-gallery.ts
+++ b/src/presets/preset-gallery.ts
@@ -1,5 +1,10 @@
 import { FeedbackId, feedbackType } from '../feedback'
-import { CompanionPresetDefinitionsExt, getFeedbackStyleSelected, getParticipantStyleDefault } from './preset-utils'
+import {
+	CompanionPresetDefinitionsExt,
+	getFeedbackStyleSelected,
+	getFeedbackStyleSpotlight,
+	getParticipantStyleDefault,
+} from './preset-utils'
 import { ActionIdGallery } from '../actions/action-gallery'
 import { padding } from '../utils'
 
@@ -27,6 +32,14 @@ export function GetPresetsListGallery(): CompanionPresetDefinitionsExt {
 				},
 			],
 			feedbacks: [
+				{
+					feedbackId: FeedbackId.galleryBased,
+					options: {
+						position: index,
+						type: feedbackType.spotlightOn,
+					},
+					style: getFeedbackStyleSpotlight(),
+				},
 				{
 					feedbackId: FeedbackId.galleryBased,
 					options: {

--- a/src/presets/preset-groups.ts
+++ b/src/presets/preset-groups.ts
@@ -1,6 +1,11 @@
 import { FeedbackId, feedbackType } from '../feedback'
 import { colorBlack, colorLightGray, ZoomGroupDataInterface } from '../utils'
-import { CompanionPresetDefinitionsExt, getFeedbackStyleSelected, getParticipantStyleDefault } from './preset-utils'
+import {
+	CompanionPresetDefinitionsExt,
+	getFeedbackStyleSelected,
+	getFeedbackStyleSpotlight,
+	getParticipantStyleDefault,
+} from './preset-utils'
 import { ActionIdGroups } from '../actions/action-group'
 
 export function GetPresetsGroups(ZoomGroupData: ZoomGroupDataInterface[]): CompanionPresetDefinitionsExt {
@@ -8,7 +13,7 @@ export function GetPresetsGroups(ZoomGroupData: ZoomGroupDataInterface[]): Compa
 
 	// Group presets
 	for (let index = 0; index < ZoomGroupData.length; index++) {
-		if (index !== 0) {
+		if (index !== 0 && index !== 1) {
 			presets[`Replace_group_${ZoomGroupData[index].groupName}`] = {
 				type: 'button',
 				category: 'Manage Selections of Groups',
@@ -163,32 +168,32 @@ export function GetPresetsGroups(ZoomGroupData: ZoomGroupDataInterface[]): Compa
 				],
 				feedbacks: [],
 			}
-		}
-		presets[`Rename_${ZoomGroupData[index].groupName}`] = {
-			type: 'button',
-			category: 'Manage Selections of Groups',
-			name: ZoomGroupData[index].groupName,
-			style: {
-				text: `Rename\\nGroup\\n$(zoomosc:Group${index})`,
-				size: '14',
-				color: colorBlack,
-				bgcolor: colorLightGray,
-			},
-			steps: [
-				{
-					down: [
-						{
-							actionId: ActionIdGroups.renameGroup,
-							options: {
-								group: index,
-								name: ZoomGroupData[index].groupName,
-							},
-						},
-					],
-					up: [],
+			presets[`Rename_${ZoomGroupData[index].groupName}`] = {
+				type: 'button',
+				category: 'Manage Selections of Groups',
+				name: ZoomGroupData[index].groupName,
+				style: {
+					text: `Rename\\nGroup\\n$(zoomosc:Group${index})`,
+					size: '14',
+					color: colorBlack,
+					bgcolor: colorLightGray,
 				},
-			],
-			feedbacks: [],
+				steps: [
+					{
+						down: [
+							{
+								actionId: ActionIdGroups.renameGroup,
+								options: {
+									group: index,
+									name: ZoomGroupData[index].groupName,
+								},
+							},
+						],
+						up: [],
+					},
+				],
+				feedbacks: [],
+			}
 		}
 
 		presets[`Select_${ZoomGroupData[index].groupName}`] = {
@@ -218,6 +223,9 @@ export function GetPresetsGroups(ZoomGroupData: ZoomGroupDataInterface[]): Compa
 		}
 
 		for (let position = 1; position < 50; position++) {
+			if (index == 1 && position > 9) {
+				break
+			}
 			presets[`Group${index}_Position${position}`] = {
 				type: 'button',
 				category: `Select ${ZoomGroupData[index].groupName} participants`,
@@ -240,10 +248,20 @@ export function GetPresetsGroups(ZoomGroupData: ZoomGroupDataInterface[]): Compa
 						options: {
 							group: index,
 							position: position,
+							type: feedbackType.spotlightOn,
+						},
+						style: getFeedbackStyleSpotlight(),
+					},
+					{
+						feedbackId: FeedbackId.groupBased,
+						options: {
+							group: index,
+							position: position,
 							type: feedbackType.selected,
 						},
 						style: getFeedbackStyleSelected(),
 					},
+
 					{
 						feedbackId: FeedbackId.groupBasedAdvanced,
 						options: {

--- a/src/presets/preset-participants.ts
+++ b/src/presets/preset-participants.ts
@@ -1,6 +1,11 @@
 import { FeedbackId, feedbackType } from '../feedback'
 import { padding } from '../utils'
-import { CompanionPresetDefinitionsExt, getFeedbackStyleSelected, getParticipantStyleDefault } from './preset-utils'
+import {
+	CompanionPresetDefinitionsExt,
+	getFeedbackStyleSelected,
+	getFeedbackStyleSpotlight,
+	getParticipantStyleDefault,
+} from './preset-utils'
 import { ActionIdUsers } from '../actions/action-user'
 
 export function GetPresetsListParticipants(): CompanionPresetDefinitionsExt {
@@ -30,6 +35,14 @@ export function GetPresetsListParticipants(): CompanionPresetDefinitionsExt {
 				},
 			],
 			feedbacks: [
+				{
+					feedbackId: FeedbackId.indexBased,
+					options: {
+						position: index,
+						type: feedbackType.spotlightOn,
+					},
+					style: getFeedbackStyleSpotlight(),
+				},
 				{
 					feedbackId: FeedbackId.indexBased,
 					options: {

--- a/src/presets/preset-utils.ts
+++ b/src/presets/preset-utils.ts
@@ -5,7 +5,7 @@ import {
 } from '@companion-module/base'
 import { ActionId } from '../actions'
 import { FeedbackId } from '../feedback'
-import { colorBlack, colorDarkGray, colorWhite } from '../utils'
+import { colorBlack, colorDarkGray, colorDarkRed, colorWhite } from '../utils'
 import { ActionIdGroups } from '../actions/action-group'
 import { ActionIdGallery } from '../actions/action-gallery'
 import { ActionIdGlobalBreakoutRooms } from '../actions/action-global-breakout-rooms'
@@ -112,6 +112,13 @@ export const getFeedbackStyleSelected = (): CompanionFeedbackButtonStyleResult =
 	return {
 		color: colorBlack,
 		bgcolor: colorDarkGray,
+	}
+}
+
+export const getFeedbackStyleSpotlight = (): CompanionFeedbackButtonStyleResult => {
+	return {
+		color: colorWhite,
+		bgcolor: colorDarkRed,
 	}
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ export const colorLightGray = combineRgb(230, 230, 230)
 export const colorBlack = combineRgb(0, 0, 0)
 export const colorWhite = combineRgb(255, 255, 255)
 export const colorRed = combineRgb(255, 0, 0)
+export const colorDarkRed = combineRgb(102, 25, 25)
 export const colorGreenOlive = combineRgb(141, 218, 77)
 export const colorTeal = combineRgb(111, 222, 222)
 
@@ -59,6 +60,7 @@ export interface ZoomUserDataInterface {
 		videoOn?: boolean
 		handRaised?: boolean
 		userRole?: number
+		spotlighted?: boolean
 		users: number[]
 	}
 }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -39,7 +39,7 @@ export function updateVariables(instance: InstanceBaseExt<ZoomConfig>): void {
 	} else {
 		const selectedCallers: string[] = []
 		instance.ZoomClientDataObj.selectedCallers.forEach((zoomID: number) => {
-			if (zoomID < instance.ZoomClientDataObj.numberOfGroups + 1) {
+			if (zoomID < instance.ZoomClientDataObj.numberOfGroups + 2) {
 				if (userExist(zoomID, instance.ZoomUserData)) {
 					instance.ZoomUserData[zoomID].users.forEach((user: string | number) => {
 						selectedCallers.push(instance.ZoomUserData[user as number].userName)
@@ -134,7 +134,11 @@ export function initVariables(instance: InstanceBaseExt<ZoomConfig>): void {
 		name: `Group${0} Position ${1}`,
 		variableId: `Group${0}Position${1}`,
 	})
-	for (let index = 1; index < instance.ZoomGroupData.length; index++) {
+	groupPositionVariables.push({
+		name: `Group${1} Position ${1}`,
+		variableId: `Group${1}Position${1}`,
+	})
+	for (let index = 2; index < instance.ZoomGroupData.length; index++) {
 		for (let position = 1; position < 2; position++) {
 			groupPositionVariables.push({
 				name: `Group${index} Position ${position}`,


### PR DESCRIPTION
this works just like the host group does.  It does replace the current group1 with the spotlight group.

 if a user is spotlighted, add them to the group.  if a user is removed from spotlight, remove them from the group.

if you join a meeting or restart the Companion module, if users are spotlighted they will be added to the group.

added spotlight on and off feedback

added to the gallery, group, and participant presets, the spotlight on feedback with a background color of dark red and white text.  The spotlight feedback is added before the selected feedback.

closes #114 