### PR TITLE
feature: truncate participant name with multi-state feedback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ class ZoomInstance extends InstanceBase<ZoomConfig> {
 
 		this.setActionDefinitions(GetActions(this))
 		this.setFeedbackDefinitions(GetFeedbacks(this))
-		this.setPresetDefinitions(GetPresetList(this.ZoomGroupData, this.ZoomUserData, this.ZoomAudioRoutingData))
+		this.setPresetDefinitions(GetPresetList(this))
 	}
 }
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,6 +1,6 @@
 import { CompanionPresetDefinitions } from '@companion-module/base'
 
-import { ZoomAudioRoutingDataInterface, ZoomGroupDataInterface, ZoomUserDataInterface } from './utils'
+import { InstanceBaseExt } from './utils'
 import { CompanionPresetDefinitionsExt } from './presets/preset-utils'
 import { GetPresetsListParticipants } from './presets/preset-participants'
 import { GetPresetsListGallery } from './presets/preset-gallery'
@@ -19,21 +19,18 @@ import { GetPresetsSharing } from './presets/preset-sharing'
 import { GetPresetsBreakout } from './presets/preset-breakout'
 import { GetPresetsRecording } from './presets/preset-recording'
 import { GetPresetsDataCustom } from './presets/preset-data-custom'
+import { ZoomConfig } from './config'
 
-export function GetPresetList(
-	ZoomGroupData: ZoomGroupDataInterface[],
-	ZoomUserData: ZoomUserDataInterface,
-	ZoomAudioRoutingData: ZoomAudioRoutingDataInterface
-): CompanionPresetDefinitions {
-	const presetsParticipants = GetPresetsListParticipants()
-	const presetsGallery = GetPresetsListGallery()
+export function GetPresetList(instance: InstanceBaseExt<ZoomConfig>): CompanionPresetDefinitions {
+	const presetsParticipants = GetPresetsListParticipants(instance)
+	const presetsGallery = GetPresetsListGallery(instance)
 	const presetsManageSelections = GetPresetsManageSelections()
-	const presetsGroups = GetPresetsGroups(ZoomGroupData)
+	const presetsGroups = GetPresetsGroups(instance)
 	const presetsPinSpotlightViewActions = GetPresetsPinSpotlightViewActions()
 	const presetsVideoAudioActions = GetPresetsVideoAudioActions()
-	const presetsZoomISOSelections = GetPresetsZoomISOSelections(ZoomAudioRoutingData)
+	const presetsZoomISOSelections = GetPresetsZoomISOSelections(instance)
 	const presetsZoomISOActions = GetPresetsZoomISOActions()
-	const presetsReactionNames = GetPresetsReactionName(ZoomUserData)
+	const presetsReactionNames = GetPresetsReactionName(instance)
 	const presetsRoleManagement = GetPresetsRoleManagement()
 	const presetsJoinLeaveEnd = GetPresetsJoinLeaveEnd()
 	const presetsDeviceSettings = GetPresetsDeviceSettings()

--- a/src/presets/preset-gallery.ts
+++ b/src/presets/preset-gallery.ts
@@ -1,22 +1,62 @@
 import { FeedbackId, feedbackType } from '../feedback'
 import {
 	CompanionPresetDefinitionsExt,
+	PresetFeedbackDefinition,
 	getFeedbackStyleSelected,
 	getFeedbackStyleSpotlight,
+	getParticipantStyleActiveSpeaker,
 	getParticipantStyleDefault,
 } from './preset-utils'
 import { ActionIdGallery } from '../actions/action-gallery'
-import { padding } from '../utils'
+import { InstanceBaseExt, padding } from '../utils'
+import { ZoomConfig } from '../config'
 
-export function GetPresetsListGallery(): CompanionPresetDefinitionsExt {
+export function GetPresetsListGallery(instance: InstanceBaseExt<ZoomConfig>): CompanionPresetDefinitionsExt {
 	const presets: CompanionPresetDefinitionsExt = {}
 
 	for (let index = 1; index < 50; index++) {
+		const galleryFeedbacks: PresetFeedbackDefinition = [
+			{
+				feedbackId: FeedbackId.galleryBased,
+				options: {
+					position: index,
+					type: feedbackType.spotlightOn,
+				},
+				style: getFeedbackStyleSpotlight(),
+			},
+			{
+				feedbackId: FeedbackId.galleryBased,
+				options: {
+					position: index,
+					type: feedbackType.selected,
+				},
+				style: getFeedbackStyleSelected(),
+			},
+		]
+
+		if (instance.config.feedbackImagesWithIcons !== 4) {
+			galleryFeedbacks.push({
+				feedbackId: FeedbackId.galleryBased,
+				options: {
+					position: index,
+					type: feedbackType.activeSpeaker,
+				},
+				style: getParticipantStyleActiveSpeaker(`$(zoomosc:GalleryPosition${padding(index, 2)})`, index),
+			})
+		}
+
+		galleryFeedbacks.push({
+			feedbackId: FeedbackId.galleryBasedAdvanced,
+			options: {
+				position: index,
+			},
+		})
+
 		presets[`Gallery_position_${index})`] = {
 			type: 'button',
 			category: 'Select from Gallery',
 			name: `$(zoomosc:Gallery position ${index})`,
-			style: getParticipantStyleDefault(`$(zoomosc:GalleryPosition${padding(index, 2)})`, index),
+			style: getParticipantStyleDefault(instance, `$(zoomosc:GalleryPosition${padding(index, 2)})`, index),
 			steps: [
 				{
 					down: [
@@ -31,30 +71,7 @@ export function GetPresetsListGallery(): CompanionPresetDefinitionsExt {
 					up: [],
 				},
 			],
-			feedbacks: [
-				{
-					feedbackId: FeedbackId.galleryBased,
-					options: {
-						position: index,
-						type: feedbackType.spotlightOn,
-					},
-					style: getFeedbackStyleSpotlight(),
-				},
-				{
-					feedbackId: FeedbackId.galleryBased,
-					options: {
-						position: index,
-						type: feedbackType.selected,
-					},
-					style: getFeedbackStyleSelected(),
-				},
-				{
-					feedbackId: FeedbackId.galleryBasedAdvanced,
-					options: {
-						position: index,
-					},
-				},
-			],
+			feedbacks: galleryFeedbacks,
 		}
 	}
 

--- a/src/presets/preset-participants.ts
+++ b/src/presets/preset-participants.ts
@@ -1,25 +1,64 @@
 import { FeedbackId, feedbackType } from '../feedback'
-import { padding } from '../utils'
+import { InstanceBaseExt, padding } from '../utils'
 import {
 	CompanionPresetDefinitionsExt,
+	PresetFeedbackDefinition,
 	getFeedbackStyleSelected,
 	getFeedbackStyleSpotlight,
+	getParticipantStyleActiveSpeaker,
 	getParticipantStyleDefault,
 } from './preset-utils'
 import { ActionIdUsers } from '../actions/action-user'
+import { ZoomConfig } from '../config'
 
-export function GetPresetsListParticipants(): CompanionPresetDefinitionsExt {
+export function GetPresetsListParticipants(instance: InstanceBaseExt<ZoomConfig>): CompanionPresetDefinitionsExt {
 	const presets: CompanionPresetDefinitionsExt = {}
 
 	/**
 	 * Select from Participants
 	 */
 	for (let index = 1; index < 1000; index++) {
+		const indexFeedbacks: PresetFeedbackDefinition = [
+			{
+				feedbackId: FeedbackId.indexBased,
+				options: {
+					position: index,
+					type: feedbackType.spotlightOn,
+				},
+				style: getFeedbackStyleSpotlight(),
+			},
+			{
+				feedbackId: FeedbackId.indexBased,
+				options: {
+					position: index,
+					type: feedbackType.selected,
+				},
+				style: getFeedbackStyleSelected(),
+			},
+		]
+
+		if (instance.config.feedbackImagesWithIcons !== 4) {
+			indexFeedbacks.push({
+				feedbackId: FeedbackId.indexBased,
+				options: {
+					position: index,
+					type: feedbackType.activeSpeaker,
+				},
+				style: getParticipantStyleActiveSpeaker(`$(zoomosc:Participant${padding(index, 3)})`, index),
+			})
+		}
+
+		indexFeedbacks.push({
+			feedbackId: FeedbackId.indexBasedAdvanced,
+			options: {
+				position: index,
+			},
+		})
 		presets[`Caller_${index}`] = {
 			type: 'button',
 			category: 'Select from Participants',
 			name: `Caller${index}`,
-			style: getParticipantStyleDefault(`$(zoomosc:Participant${padding(index, 3)})`, index),
+			style: getParticipantStyleDefault(instance, `$(zoomosc:Participant${padding(index, 3)})`, index),
 			steps: [
 				{
 					down: [
@@ -34,30 +73,7 @@ export function GetPresetsListParticipants(): CompanionPresetDefinitionsExt {
 					up: [],
 				},
 			],
-			feedbacks: [
-				{
-					feedbackId: FeedbackId.indexBased,
-					options: {
-						position: index,
-						type: feedbackType.spotlightOn,
-					},
-					style: getFeedbackStyleSpotlight(),
-				},
-				{
-					feedbackId: FeedbackId.indexBased,
-					options: {
-						position: index,
-						type: feedbackType.selected,
-					},
-					style: getFeedbackStyleSelected(),
-				},
-				{
-					feedbackId: FeedbackId.indexBasedAdvanced,
-					options: {
-						position: index,
-					},
-				},
-			],
+			feedbacks: indexFeedbacks,
 		}
 	}
 

--- a/src/presets/preset-reaction-name.ts
+++ b/src/presets/preset-reaction-name.ts
@@ -1,12 +1,13 @@
 import { ActionIdUserHandRaised } from '../actions/action-user-hand-raised'
-import { ZoomUserDataInterface, colorBlack, colorLightGray, colorTeal, userExist } from '../utils'
+import { InstanceBaseExt, ZoomUserDataInterface, colorBlack, colorLightGray, colorTeal, userExist } from '../utils'
 import { CompanionPresetDefinitionsExt } from './preset-utils'
 import { ActionIdUserRolesAndAction } from '../actions/action-user-roles-action'
 import { ActionIdGlobal } from '../actions/action-global'
+import { ZoomConfig } from '../config'
 
-export function GetPresetsReactionName(ZoomUserData: ZoomUserDataInterface): CompanionPresetDefinitionsExt {
+export function GetPresetsReactionName(instance: InstanceBaseExt<ZoomConfig>): CompanionPresetDefinitionsExt {
 	const presets: CompanionPresetDefinitionsExt = {}
-
+	const zoomUserData: ZoomUserDataInterface = instance.zoomUserData
 	/**
 	 * Reaction & Name Actions
 	 */
@@ -106,9 +107,9 @@ export function GetPresetsReactionName(ZoomUserData: ZoomUserDataInterface): Com
 	}
 
 	// User selection
-	for (const key in ZoomUserData) {
-		if (userExist(Number(key), ZoomUserData)) {
-			const user = ZoomUserData[key]
+	for (const key in zoomUserData) {
+		if (userExist(Number(key), zoomUserData)) {
+			const user = zoomUserData[key]
 			presets[`Rename_Participant_${user.zoomId}`] = {
 				type: 'button',
 				category: 'Reaction & Name Actions',

--- a/src/presets/preset-utils.ts
+++ b/src/presets/preset-utils.ts
@@ -5,7 +5,7 @@ import {
 } from '@companion-module/base'
 import { ActionId } from '../actions'
 import { FeedbackId } from '../feedback'
-import { colorBlack, colorDarkGray, colorDarkRed, colorWhite } from '../utils'
+import { InstanceBaseExt, colorBlack, colorDarkGray, colorDarkRed, colorWhite } from '../utils'
 import { ActionIdGroups } from '../actions/action-group'
 import { ActionIdGallery } from '../actions/action-gallery'
 import { ActionIdGlobalBreakoutRooms } from '../actions/action-global-breakout-rooms'
@@ -31,13 +31,16 @@ import { ActionIdZoomISOOutputSettings } from '../actions/action-zoomiso-output-
 import { ActionIdZoomISORouting } from '../actions/action-zoomiso-routing'
 import { ActionIdZoomISOActions } from '../actions/action-zoomiso-actions'
 import { ActionIdUsers } from '../actions/action-user'
+import { ZoomConfig } from '../config'
+
+export type PresetFeedbackDefinition = Array<
+	{
+		feedbackId: FeedbackId
+	} & CompanionButtonPresetDefinition['feedbacks'][0]
+>
 
 export interface CompanionPresetExt extends CompanionButtonPresetDefinition {
-	feedbacks: Array<
-		{
-			feedbackId: FeedbackId
-		} & CompanionButtonPresetDefinition['feedbacks'][0]
-	>
+	feedbacks: PresetFeedbackDefinition
 	steps: Array<{
 		down: Array<
 			{
@@ -106,8 +109,12 @@ export interface CompanionPresetExt extends CompanionButtonPresetDefinition {
 export interface CompanionPresetDefinitionsExt {
 	[id: string]: CompanionPresetExt | undefined
 }
+
+export const buttonTextDefaultLength = 50
+export const buttonTextActiveSpeakerLength = 40
 export const alignmentTopLeft = 'left:top'
 export const alignmentTopCenter = 'center:top'
+
 export const getFeedbackStyleSelected = (): CompanionFeedbackButtonStyleResult => {
 	return {
 		color: colorBlack,
@@ -122,12 +129,28 @@ export const getFeedbackStyleSpotlight = (): CompanionFeedbackButtonStyleResult 
 	}
 }
 
-export const getParticipantStyleDefault = (text: string, position: number): CompanionButtonStyleProps => {
+export const getParticipantStyleDefault = (
+	instance: InstanceBaseExt<ZoomConfig>,
+	text: string,
+	position: number
+): CompanionButtonStyleProps => {
 	return {
-		text: `\\n${position}. ${text}`,
+		text:
+			instance.config.feedbackImagesWithIcons === 4
+				? `${position}. ${text}`
+				: `\`${position}. \${substr(${text},0,${buttonTextDefaultLength})}\``,
 		size: '7',
 		color: colorWhite,
 		bgcolor: colorBlack,
 		alignment: alignmentTopCenter,
-	}
+		show_topbar: false,
+		textExpression: instance.config.feedbackImagesWithIcons === 4 ? false : true,
+	} as CompanionButtonStyleProps
+}
+
+export const getParticipantStyleActiveSpeaker = (text: string, position: number): CompanionButtonStyleProps => {
+	return {
+		text: `\`\\n${position}. \${substr(${text},0,${buttonTextActiveSpeakerLength})}\``,
+		alignment: alignmentTopLeft,
+	} as CompanionButtonStyleProps
 }

--- a/src/presets/preset-zoomiso-selections.ts
+++ b/src/presets/preset-zoomiso-selections.ts
@@ -1,13 +1,12 @@
 import { FeedbackId } from '../feedback'
-import { ZoomAudioRoutingDataInterface, colorBlack, colorGreenOlive, colorRed } from '../utils'
+import { InstanceBaseExt, ZoomAudioRoutingDataInterface, colorBlack, colorGreenOlive, colorRed } from '../utils'
 import { CompanionPresetDefinitionsExt } from './preset-utils'
 import { ActionIdZoomISOActions } from '../actions/action-zoomiso-actions'
+import { ZoomConfig } from '../config'
 
-export function GetPresetsZoomISOSelections(
-	ZoomAudioRoutingData: ZoomAudioRoutingDataInterface
-): CompanionPresetDefinitionsExt {
+export function GetPresetsZoomISOSelections(instance: InstanceBaseExt<ZoomConfig>): CompanionPresetDefinitionsExt {
 	const presets: CompanionPresetDefinitionsExt = {}
-
+	const zoomAudioRoutingData: ZoomAudioRoutingDataInterface = instance.ZoomAudioRoutingData
 	/**
 	 * ZoomISO Selections
 	 */
@@ -82,7 +81,7 @@ export function GetPresetsZoomISOSelections(
 	}
 	for (
 		let index = 1;
-		index < (Object.keys(ZoomAudioRoutingData).length === 0 ? 9 : Object.keys(ZoomAudioRoutingData).length + 1);
+		index < (Object.keys(zoomAudioRoutingData).length === 0 ? 9 : Object.keys(zoomAudioRoutingData).length + 1);
 		index++
 	) {
 		presets[`Select_Output_${index}`] = {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -138,6 +138,8 @@ export function initVariables(instance: InstanceBaseExt<ZoomConfig>): void {
 		name: `Group${1} Position ${1}`,
 		variableId: `Group${1}Position${1}`,
 	})
+	userVariables.push({ name: `name`, variableId: `Group0` })
+	userVariables.push({ name: `name`, variableId: `Group1` })
 	for (let index = 2; index < instance.ZoomGroupData.length; index++) {
 		for (let position = 1; position < 2; position++) {
 			groupPositionVariables.push({


### PR DESCRIPTION
when using multi-state feedback truncate the user name to 50 characters when not the active speaker and when the active speaker truncate the user name to 40 characters.  This tries to stop the user name from sitting on top of the multi-state icons at the bottom and multi-state active speaker at the top.

