### PR TITLE
update: lite message and add PRO to all PRO only action descriptions

### DIFF
--- a/src/actions/action-global-breakout-rooms.ts
+++ b/src/actions/action-global-breakout-rooms.ts
@@ -19,7 +19,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 } {
 	const actions: { [id in ActionIdGlobalBreakoutRooms]: CompanionActionDefinition | undefined } = {
 		[ActionIdGlobalBreakoutRooms.openBreakoutRooms]: {
-			name: 'Open Breakout Rooms',
+			name: 'Open Breakout Rooms (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -35,7 +35,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 			},
 		},
 		[ActionIdGlobalBreakoutRooms.closeBreakoutRooms]: {
-			name: 'Close Breakout Rooms',
+			name: 'Close Breakout Rooms (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -51,7 +51,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 			},
 		},
 		[ActionIdGlobalBreakoutRooms.deleteAllBreakoutRooms]: {
-			name: 'Delete All Breakout Rooms',
+			name: 'Delete All Breakout Rooms (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -67,7 +67,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 			},
 		},
 		[ActionIdGlobalBreakoutRooms.requestListOfBreakoutRooms]: {
-			name: 'Request list of breakout rooms',
+			name: 'Request list of breakout rooms (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -83,7 +83,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 			},
 		},
 		[ActionIdGlobalBreakoutRooms.configureBreakoutRooms]: {
-			name: 'Configure BreakoutRooms',
+			name: 'Configure BreakoutRooms (PRO)',
 			options: [
 				options.postCloseSeconds,
 				options.allowChooseBreakout,
@@ -114,7 +114,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 			},
 		},
 		[ActionIdGlobalBreakoutRooms.createBreakoutRoom]: {
-			name: 'Create Breakout Room',
+			name: 'Create Breakout Room (PRO)',
 			options: [options.name],
 			callback: async (action): Promise<void> => {
 				// type: 'Global'
@@ -132,7 +132,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 			},
 		},
 		[ActionIdGlobalBreakoutRooms.deleteBreakoutRoom]: {
-			name: 'Delete Breakout Room',
+			name: 'Delete Breakout Room (PRO)',
 			options: [options.name],
 			callback: async (action): Promise<void> => {
 				// type: 'Global'
@@ -150,7 +150,7 @@ export function GetActionsGlobalBreakoutRooms(instance: InstanceBaseExt<ZoomConf
 			},
 		},
 		[ActionIdGlobalBreakoutRooms.broadcastMessageToBreakoutRooms]: {
-			name: 'Broadcast Message To Breakout Rooms',
+			name: 'Broadcast Message To Breakout Rooms (PRO)',
 			options: [options.message],
 			callback: (action): void => {
 				// type: 'Global'

--- a/src/actions/action-global-memory-management.ts
+++ b/src/actions/action-global-memory-management.ts
@@ -12,7 +12,7 @@ export function GetActionsGlobalMemoryManagement(instance: InstanceBaseExt<ZoomC
 } {
 	const actions: { [id in ActionIdGlobalMemoryManagement]: CompanionActionDefinition | undefined } = {
 		[ActionIdGlobalMemoryManagement.listUsers]: {
-			name: 'Request list of Participants',
+			name: 'Request list of Participants (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Special'

--- a/src/actions/action-global-waitingrooms-and-zak.ts
+++ b/src/actions/action-global-waitingrooms-and-zak.ts
@@ -17,7 +17,7 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 } {
 	const actions: { [id in ActionIdGlobalWaitingRoomsAndZak]: CompanionActionDefinition | undefined } = {
 		[ActionIdGlobalWaitingRoomsAndZak.admitEveryoneFromWaitingRoom]: {
-			name: 'Admit All',
+			name: 'Admit All (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -33,7 +33,7 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 			},
 		},
 		[ActionIdGlobalWaitingRoomsAndZak.enableWaitingRoom]: {
-			name: 'Enable Waiting Room',
+			name: 'Enable Waiting Room (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -49,7 +49,7 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 			},
 		},
 		[ActionIdGlobalWaitingRoomsAndZak.disableWaitingRoom]: {
-			name: 'Disable Waiting Room',
+			name: 'Disable Waiting Room (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -65,7 +65,7 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 			},
 		},
 		[ActionIdGlobalWaitingRoomsAndZak.sendMessageToWaitingRoom]: {
-			name: 'Send Message To Waiting Room',
+			name: 'Send Message To Waiting Room (PRO)',
 			options: [options.message],
 			callback: (action): void => {
 				// type: 'Global'
@@ -82,7 +82,7 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 			},
 		},
 		[ActionIdGlobalWaitingRoomsAndZak.ZAKJoinMeeting]: {
-			name: 'ZAK Join Meeting',
+			name: 'ZAK Join Meeting (PRO)',
 			options: [options.zak, options.meetingID, options.name],
 			callback: async (action): Promise<void> => {
 				// type: 'Special'
@@ -102,7 +102,7 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 			},
 		},
 		[ActionIdGlobalWaitingRoomsAndZak.ZAKStartMeeting]: {
-			name: 'ZAK Start Meeting',
+			name: 'ZAK Start Meeting (PRO)',
 			options: [options.zak, options.meetingID, options.name],
 			callback: async (action): Promise<void> => {
 				// type: 'Special'

--- a/src/actions/action-global.ts
+++ b/src/actions/action-global.ts
@@ -138,7 +138,7 @@ export function GetActionsGlobal(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdGlobal.clearSpotlight]: {
-			name: 'Clear Spotlight',
+			name: 'Clear Spotlight (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -233,7 +233,7 @@ export function GetActionsGlobal(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdGlobal.leaveMeeting]: {
-			name: 'Leave Meeting',
+			name: 'Leave Meeting (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -249,7 +249,7 @@ export function GetActionsGlobal(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdGlobal.endMeeting]: {
-			name: 'End Meeting',
+			name: 'End Meeting (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -300,7 +300,7 @@ export function GetActionsGlobal(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdGlobal.joinMeeting]: {
-			name: 'Join Meeting',
+			name: 'Join Meeting (PRO)',
 			options: [options.meetingID, options.password, options.name],
 			callback: async (action): Promise<void> => {
 				// type: 'Special'

--- a/src/actions/action-user-breakout-rooms.ts
+++ b/src/actions/action-user-breakout-rooms.ts
@@ -16,7 +16,7 @@ export function GetActionsUserBreakoutRooms(instance: InstanceBaseExt<ZoomConfig
 } {
 	const actions: { [id in ActionIdUserBreakoutRooms]: CompanionActionDefinition | undefined } = {
 		[ActionIdUserBreakoutRooms.sendParticipantToBreakoutRoom]: {
-			name: 'Send Participant To BreakoutRoom',
+			name: 'Send Participant To BreakoutRoom (PRO)',
 			options: [options.userName, options.breakoutName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -36,7 +36,7 @@ export function GetActionsUserBreakoutRooms(instance: InstanceBaseExt<ZoomConfig
 			},
 		},
 		[ActionIdUserBreakoutRooms.removeParticipantFromBreakoutRoom]: {
-			name: 'Remove Participant From BreakoutRoom',
+			name: 'Remove Participant From BreakoutRoom (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -55,7 +55,7 @@ export function GetActionsUserBreakoutRooms(instance: InstanceBaseExt<ZoomConfig
 			},
 		},
 		[ActionIdUserBreakoutRooms.assignParticipantToBreakoutRoom]: {
-			name: 'Assign Participant To BreakoutRoom',
+			name: 'Assign Participant To BreakoutRoom (PRO)',
 			options: [options.userName, options.breakoutName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -76,7 +76,7 @@ export function GetActionsUserBreakoutRooms(instance: InstanceBaseExt<ZoomConfig
 			},
 		},
 		[ActionIdUserBreakoutRooms.unassignParticipantFromBreakoutRoom]: {
-			name: 'Unassign Participant From BreakoutRoom',
+			name: 'Unassign Participant From BreakoutRoom (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'

--- a/src/actions/action-user-hand-raised.ts
+++ b/src/actions/action-user-hand-raised.ts
@@ -52,7 +52,7 @@ export function GetActionsUserHandRaised(instance: InstanceBaseExt<ZoomConfig>):
 			},
 		},
 		[ActionIdUserHandRaised.toggleHand]: {
-			name: 'Toggle Hand',
+			name: 'Toggle Hand (Windows Only)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'

--- a/src/actions/action-user-pin.ts
+++ b/src/actions/action-user-pin.ts
@@ -39,7 +39,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserPin.addPin]: {
-			name: 'Add Pin',
+			name: 'Add Pin (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -77,7 +77,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserPin.clearPins]: {
-			name: 'Clear Pins',
+			name: 'Clear Pins (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -93,7 +93,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserPin.togglePin]: {
-			name: 'Toggle Pin',
+			name: 'Toggle Pin (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -166,7 +166,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserPin.togglePinScreen2]: {
-			name: 'Toggle PinScreen2',
+			name: 'Toggle PinScreen2 (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'

--- a/src/actions/action-user-roles-action.ts
+++ b/src/actions/action-user-roles-action.ts
@@ -108,7 +108,7 @@ export function GetActionsUserRolesAndAction(instance: InstanceBaseExt<ZoomConfi
 		},
 		// Rename Actions
 		[ActionIdUserRolesAndAction.rename]: {
-			name: 'Rename',
+			name: 'Rename (PRO)',
 			options: [userOption, options.name],
 			callback: async (action) => {
 				const newName = await instance.parseVariablesInString(action.options.name as string)
@@ -295,7 +295,7 @@ export function GetActionsUserRolesAndAction(instance: InstanceBaseExt<ZoomConfi
 			},
 		},
 		[ActionIdUserRolesAndAction.allowToRecord]: {
-			name: 'Allow To Record',
+			name: 'Allow To Record (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -314,7 +314,7 @@ export function GetActionsUserRolesAndAction(instance: InstanceBaseExt<ZoomConfi
 			},
 		},
 		[ActionIdUserRolesAndAction.disallowToRecord]: {
-			name: 'Disallow To Record',
+			name: 'Disallow To Record (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'

--- a/src/actions/action-user-screenshare.ts
+++ b/src/actions/action-user-screenshare.ts
@@ -24,7 +24,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 } {
 	const actions: { [id in ActionIdUserScreenshare]: CompanionActionDefinition | undefined } = {
 		[ActionIdUserScreenshare.startScreenShare]: {
-			name: 'Screen Share',
+			name: 'Screen Share (PRO)',
 			options: [options.id],
 			callback: (action): void => {
 				// type: 'Global'
@@ -41,7 +41,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.enableOptimizeVideoForSharing]: {
-			name: 'Enable Optimize Video For Sharing',
+			name: 'Enable Optimize Video For Sharing (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -57,7 +57,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.disableOptimizeVideoForSharing]: {
-			name: 'Disable Optimize Video For Sharing',
+			name: 'Disable Optimize Video For Sharing (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -73,7 +73,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.enableComputerSoundWhenSharing]: {
-			name: 'Enable Computer Sound When Sharing',
+			name: 'Enable Computer Sound When Sharing (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -89,7 +89,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.disableComputerSoundWhenSharing]: {
-			name: 'Disable Computer Sound When Sharing',
+			name: 'Disable Computer Sound When Sharing (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -121,7 +121,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.cycleSharedCameraToNextAvailable]: {
-			name: 'Cycle Shared Camera To Next Available',
+			name: 'Cycle Shared Camera To Next Available (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -153,7 +153,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.startCameraShare]: {
-			name: 'Start CameraShare',
+			name: 'Start CameraShare (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -169,7 +169,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.SetWindowPosition]: {
-			name: 'Set Window Position',
+			name: 'Set Window Position  (PRO and MAC Only)',
 			options: [options.userName, options.intX, options.intY],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -190,7 +190,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.SetWindowSize]: {
-			name: 'Set Window Size',
+			name: 'Set Window Size  (PRO and MAC Only)',
 			options: [options.userName, options.intX, options.intY],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -211,7 +211,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.startShareWithWindow]: {
-			name: 'Share Window',
+			name: 'Share Window  (PRO and MAC Only)',
 			options: [options.id],
 			callback: (action): void => {
 				// type: 'Global'
@@ -228,7 +228,7 @@ export function GetActionsUserScreenshare(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserScreenshare.startAudioShare]: {
-			name: 'Start AudioShare',
+			name: 'Start AudioShare (PRO and Windows)',
 			options: [options.id],
 			callback: (action): void => {
 				// type: 'Global'

--- a/src/actions/action-user-settings.ts
+++ b/src/actions/action-user-settings.ts
@@ -30,7 +30,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 } {
 	const actions: { [id in ActionIdUserSettings]: CompanionActionDefinition | undefined } = {
 		[ActionIdUserSettings.hideSelfView]: {
-			name: 'Hide Self View',
+			name: 'Hide Self View  (PRO and MAC Only)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -46,7 +46,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.showSelfView]: {
-			name: 'Show Self View',
+			name: 'Show Self View (PRO and MAC Only)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -164,7 +164,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.enableHDVideo]: {
-			name: 'Enable HD Video',
+			name: 'Enable HD Video (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -180,7 +180,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.disableHDVideo]: {
-			name: 'Disable HD Video',
+			name: 'Disable HD Video (PRO)',
 			options: [],
 			callback: (): void => {
 				// type: 'Global'
@@ -196,7 +196,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.enableMirrorVideo]: {
-			name: 'Enable Mirror Video',
+			name: 'Enable Mirror Video (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -215,7 +215,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.disableMirrorVideo]: {
-			name: 'Disable Mirror Video',
+			name: 'Disable Mirror Video (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -234,7 +234,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.setVirtualBackground]: {
-			name: 'Set Virtual Background',
+			name: 'Set Virtual Background (PRO and MAC Only)',
 			options: [options.userName, options.id],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -254,7 +254,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.setVideoFilter]: {
-			name: 'Set Video Filter',
+			name: 'Set Video Filter (PRO and MAC Only)',
 			options: [options.userName, options.id],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -274,7 +274,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.setCameraDevice]: {
-			name: 'Set Camera Device',
+			name: 'Set Camera Device (PRO)',
 			options: [options.userName, options.id],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -294,7 +294,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.setSpeakerVolume]: {
-			name: 'Set Speaker Volume',
+			name: 'Set Speaker Volume (PRO)',
 			options: [options.userName, options.level],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -314,7 +314,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.setSpeakerDevice]: {
-			name: 'Set Speaker Device',
+			name: 'Set Speaker Device (PRO)',
 			options: [options.userName, options.id],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -334,7 +334,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.setMicDevice]: {
-			name: 'Set Mic Device',
+			name: 'Set Mic Device (PRO)',
 			options: [options.userName, options.id],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -354,7 +354,7 @@ export function GetActionsUserSettings(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserSettings.setMicLevel]: {
-			name: 'Set Mic Level',
+			name: 'Set Mic Level (PRO)',
 			options: [options.level],
 			callback: (action): void => {
 				// type: 'User'

--- a/src/actions/action-user-spotlight.ts
+++ b/src/actions/action-user-spotlight.ts
@@ -34,7 +34,7 @@ export function GetActionsUserSpotlight(instance: InstanceBaseExt<ZoomConfig>): 
 			},
 		},
 		[ActionIdUserSpotlight.addSpotlight]: {
-			name: 'Add Spotlight',
+			name: 'Add Spotlight (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -72,7 +72,7 @@ export function GetActionsUserSpotlight(instance: InstanceBaseExt<ZoomConfig>): 
 			},
 		},
 		[ActionIdUserSpotlight.toggleSpotlight]: {
-			name: 'Toggle Spotlight',
+			name: 'Toggle Spotlight (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'

--- a/src/actions/action-user-waiting-room.ts
+++ b/src/actions/action-user-waiting-room.ts
@@ -13,7 +13,7 @@ export function GetActionsUserWaitingRoom(instance: InstanceBaseExt<ZoomConfig>)
 } {
 	const actions: { [id in ActionIdUserWaitingRoom]: CompanionActionDefinition | undefined } = {
 		[ActionIdUserWaitingRoom.admitSomeoneFromWaitingRoom]: {
-			name: 'Admit Participant',
+			name: 'Admit Participant (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -32,7 +32,7 @@ export function GetActionsUserWaitingRoom(instance: InstanceBaseExt<ZoomConfig>)
 			},
 		},
 		[ActionIdUserWaitingRoom.sendSomeoneToWaitingRoom]: {
-			name: 'Send To Waiting Room',
+			name: 'Send To Waiting Room (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'

--- a/src/actions/action-user-webinars.ts
+++ b/src/actions/action-user-webinars.ts
@@ -13,7 +13,7 @@ export function GetActionsUserWebinar(instance: InstanceBaseExt<ZoomConfig>): {
 } {
 	const actions: { [id in ActionIdUserWebinar]: CompanionActionDefinition | undefined } = {
 		[ActionIdUserWebinar.allowWebinarAttendeeToSpeak]: {
-			name: 'Allow to Speak',
+			name: 'Allow to Speak (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'
@@ -32,7 +32,7 @@ export function GetActionsUserWebinar(instance: InstanceBaseExt<ZoomConfig>): {
 			},
 		},
 		[ActionIdUserWebinar.disallowToSpeak]: {
-			name: 'Disallow to Speak',
+			name: 'Disallow to Speak (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
 				// type: 'User'

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,6 @@ export interface ZoomConfig {
 	numberOfGroups: number
 	pulling: number
 	feedbackImagesWithIcons: number
-	licenseType: string
 }
 
 export const GetConfigFields = (): SomeCompanionConfigField[] => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export const GetConfigFields = (): SomeCompanionConfigField[] => {
 			type: 'static-text',
 			width: 12,
 			value:
-				'Please make sure you have the following settings corectly in your OSC/ISO client;</br>"Subscribe to:" <b>All</b></br>"Gallery Tracking Mode:" <b>ZoomID</b><br><br>Note: If you are using the lite version, some core functionality like the gallery tracking will not work as it requires actions that only work with the PRO license.  As well, only the actions that are not listed as PRO in the <a href="https://www.liminalet.com/zoomosc-resources">ZoomOSC API Guide</a> and the <a href="https://www.liminalet.com/zoomiso">ZoomISO Documentation</a> work with the lite version',
+				'Please make sure you have the following settings corectly in your OSC/ISO client;</br>"Subscribe to:" <b>All</b></br>"Gallery Tracking Mode:" <b>ZoomID</b>',
 			id: 'info on license',
 			label: 'Important note',
 		},

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export interface ZoomConfig {
 	numberOfGroups: number
 	pulling: number
 	feedbackImagesWithIcons: number
+	licenseType: string
 }
 
 export const GetConfigFields = (): SomeCompanionConfigField[] => {
@@ -18,7 +19,7 @@ export const GetConfigFields = (): SomeCompanionConfigField[] => {
 			type: 'static-text',
 			width: 12,
 			value:
-				'Please make sure you have the following settings corectly in your OSC/ISO client;</br>"Subscribe to:" <b>All</b></br>"Gallery Tracking Mode:" <b>ZoomID</b>',
+				'Please make sure you have the following settings corectly in your OSC/ISO client;</br>"Subscribe to:" <b>All</b></br>"Gallery Tracking Mode:" <b>ZoomID</b><br><br>Note: If you are using the lite version, some core functionality like the gallery tracking will not work as it requires actions that only work with the PRO license.  As well, only the actions that are not listed as PRO in the <a href="https://www.liminalet.com/zoomosc-resources">ZoomOSC API Guide</a> and the <a href="https://www.liminalet.com/zoomiso">ZoomISO Documentation</a> work with the lite version',
 			id: 'info on license',
 			label: 'Important note',
 		},
@@ -106,6 +107,14 @@ export const GetConfigFields = (): SomeCompanionConfigField[] => {
 			],
 			default: 1,
 			width: 6,
+		},
+		{
+			type: 'static-text',
+			width: 12,
+			value:
+				'If you are using the lite version of ZoomOSC or ZoomISO, some core functionality like the gallery tracking will not work as it requires commands that are only available in the PRO version and ZoomISO is limitged to a maximum of 4 outputs.  As well, only the actions that are not listed as PRO in the <a target="_blank" href="https://www.liminalet.com/zoomosc-resources">ZoomOSC API/Command List</a> and the <a target="_blank" href="https://www.liminalet.com/zoomiso">ZoomISO Documentation (User Guide)</a> work with the lite version',
+			id: 'liteNote',
+			label: 'If You Are Using The Lite Version',
 		},
 	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ class ZoomInstance extends InstanceBase<ZoomConfig> {
 		numberOfGroups: 0,
 		pulling: 0,
 		feedbackImagesWithIcons: 1,
-		licenseType: '',
 	}
 
 	// Global call settings

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ class ZoomInstance extends InstanceBase<ZoomConfig> {
 		numberOfGroups: 0,
 		pulling: 0,
 		feedbackImagesWithIcons: 1,
+		licenseType: '',
 	}
 
 	// Global call settings

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -540,10 +540,8 @@ export class OSC {
 					// // {int isPro (1=true, 0-false)}
 					const versionInfo = data.args[1].value as string
 					if (data.args[7].value === 1) {
-						this.instance.config.licenseType = 'PRO'
 						this.instance.updateStatus(InstanceStatus.Ok)
 					} else if (data.args[7].value === 0 || data.args[1].value.includes('lite')) {
-						this.instance.config.licenseType = 'LITE'
 						this.instance.updateStatus(InstanceStatus.Ok)
 						// this.instance.updateStatus(InstanceStatus.UnknownError, 'LIMITED, UNLICENSED')
 					}

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -540,9 +540,12 @@ export class OSC {
 					// // {int isPro (1=true, 0-false)}
 					const versionInfo = data.args[1].value as string
 					if (data.args[7].value === 1) {
+						this.instance.config.licenseType = 'PRO'
 						this.instance.updateStatus(InstanceStatus.Ok)
 					} else if (data.args[7].value === 0 || data.args[1].value.includes('lite')) {
-						this.instance.updateStatus(InstanceStatus.UnknownError, 'LIMITED, UNLICENSED')
+						this.instance.config.licenseType = 'LITE'
+						this.instance.updateStatus(InstanceStatus.Ok)
+						// this.instance.updateStatus(InstanceStatus.UnknownError, 'LIMITED, UNLICENSED')
 					}
 
 					this.instance.log('debug', `${versionInfo} ${data.args[7].value === 1 ? 'Pro' : 'Lite or Essentials'}`)


### PR DESCRIPTION
### For PRO Only Actions, the description has (PRO) added to the end.  As well if it is a Win or Mac only action, included a Windows Only or Mac Only text in addition to the PRO.

![image](https://github.com/bitfocus/companion-module-zoom-osc-iso/assets/708423/971c5774-38ec-483a-a006-2c73f4861939)

### On the configuration page there is a note about if you are using the lite version.  There was not a great way to be able to auto detect and dynamically change the configuration page.

![image](https://github.com/bitfocus/companion-module-zoom-osc-iso/assets/708423/0c2c6ee8-edb3-4ea0-8c67-0d5c7d86c62d)

fixes #161 
