### PR TITLE
add: chat messages to social stream ninja

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zoom-osc-iso",
-	"version": "3.14.0",
+	"version": "3.15.0",
 	"main": "dist/index.js",
 	"repository": {
 		"type": "git",
@@ -16,21 +16,23 @@
 		"build:main": "tsc -p tsconfig.build.json",
 		"build:watch": "tsc -p tsconfig.build.json --watch",
 		"lint:raw": "eslint --ext .ts --ext .js --ignore-pattern dist --ignore-pattern pkg",
-		"lint": "yarn lint:raw ."		
+		"lint": "yarn lint:raw ."
 	},
 	"license": "MIT",
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"dependencies": {
-		"@companion-module/base": "~1.7.0",
+		"@companion-module/base": "~1.8.0",
+		"@types/got": "^9.6.12",
+		"got-cjs": "^12.5.4",
 		"osc": "^2.4.3"
 	},
 	"devDependencies": {
-		"@companion-module/tools": "^1.4.2",
+		"@companion-module/tools": "^1.5.0",
+		"@types/node": "^20.0.0",
 		"husky": "^9.0.10",
 		"lint-staged": "^15.2.2",
-		"typescript": "^5.3.3",
-		"@types/node": "^20.0.0",
-		"rimraf": "^5.0.1"		
+		"rimraf": "^5.0.1",
+		"typescript": "^5.3.3"
 	},
 	"lint-staged": {
 		"*.{css,json,md,scss}": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"dependencies": {
 		"@companion-module/base": "~1.8.0",
-		"@types/got": "^9.6.12",
 		"got-cjs": "^12.5.4",
 		"osc": "^2.4.3"
 	},
@@ -32,7 +31,8 @@
 		"husky": "^9.0.10",
 		"lint-staged": "^15.2.2",
 		"rimraf": "^5.0.1",
-		"typescript": "^5.3.3"
+		"typescript": "^5.3.3",
+		"@types/got": "^9.6.12"
 	},
 	"lint-staged": {
 		"*.{css,json,md,scss}": [

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
 	"license": "MIT",
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"dependencies": {
-		"@companion-module/base": "~1.8.0",
+		"@companion-module/base": "~1.7.0",
 		"got-cjs": "^12.5.4",
 		"osc": "^2.4.3"
 	},
 	"devDependencies": {
-		"@companion-module/tools": "^1.5.0",
+		"@companion-module/tools": "^1.4.2",
 		"@types/node": "^20.0.0",
 		"husky": "^9.0.10",
 		"lint-staged": "^15.2.2",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -20,6 +20,7 @@ import {
 	GetActionsGlobalWaitingRoomsAndZak,
 } from './actions/action-global-waitingrooms-and-zak.js'
 import { ActionIdGlobal, GetActionsGlobal } from './actions/action-global.js'
+import { ActionIdGlobalChat, GetActionsGlobalChat } from './actions/action-global-chat.js'
 import { ActionIdUserBreakoutRooms, GetActionsUserBreakoutRooms } from './actions/action-user-breakout-rooms.js'
 import { ActionIdUserChat, GetActionsUserChat } from './actions/action-user-chat.js'
 import { ActionIdUserHandRaised, GetActionsUserHandRaised } from './actions/action-user-hand-raised.js'
@@ -37,15 +38,13 @@ import {
 	ActionIdZoomISOOutputSettings,
 	GetActionsZoomISOOutputSettings,
 } from './actions/action-zoomiso-output-settings.js'
+import { ActionIdZoomISOConfig, GetActionsZoomISOConfig } from './actions/action-zoomiso-config.js'
 import { ActionIdZoomISORouting, GetActionsZoomISORouting } from './actions/action-zoomiso-routing.js'
 import { ActionIdZoomISOActions, GetActionsZoomISOActions } from './actions/action-zoomiso-actions.js'
 import { ActionIdUsers, GetActionsUsers } from './actions/action-user.js'
+import { ActionIdSocialStream, GetActionsSocalSteam } from './actions/action-social-stream.js'
 
 export enum ActionId {
-	loadISOConfig = 'load_ISO_Config',
-	saveISOConfig = 'save_ISO_Config',
-	mergeISOConfig = 'merge_ISO_Config',
-	getConfigPath = 'get_Config_Path',
 	acceptRecordingConsent = 'accept_Recording_Consent',
 	customCommandWithArguments = 'customCommandWithArguments',
 	customCommand = 'customCommand',
@@ -102,6 +101,9 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 
 	const actionGlobal: { [id in ActionIdGlobal]: CompanionActionDefinition | undefined } = GetActionsGlobal(instance)
 
+	const actionGlobalChat: { [id in ActionIdGlobalChat]: CompanionActionDefinition | undefined } =
+		GetActionsGlobalChat(instance)
+
 	const actionGlobalBreakoutRooms: { [id in ActionIdGlobalBreakoutRooms]: CompanionActionDefinition | undefined } =
 		GetActionsGlobalBreakoutRooms(instance)
 
@@ -119,6 +121,9 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 	const actionZoomISORouting: { [id in ActionIdZoomISORouting]: CompanionActionDefinition | undefined } =
 		GetActionsZoomISORouting(instance)
 
+	const actionZoomISOConfig: { [id in ActionIdZoomISOConfig]: CompanionActionDefinition | undefined } =
+		GetActionsZoomISOConfig(instance)
+
 	const actionZoomISOEngine: { [id in ActionIdZoomISOEngine]: CompanionActionDefinition | undefined } =
 		GetActionsZoomISOEngine(instance)
 
@@ -129,6 +134,9 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 		GetActionsZoomISOActions(instance)
 
 	const actionUsers: { [id in ActionIdUsers]: CompanionActionDefinition | undefined } = GetActionsUsers(instance)
+
+	const actionSocialStream: { [id in ActionIdSocialStream]: CompanionActionDefinition | undefined } =
+		GetActionsSocalSteam(instance)
 
 	const actions: {
 		[id in
@@ -141,6 +149,7 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			| ActionIdGlobalRecording
 			| ActionIdGlobalWaitingRoomsAndZak
 			| ActionIdGlobal
+			| ActionIdGlobalChat
 			| ActionIdUserBreakoutRooms
 			| ActionIdUserChat
 			| ActionIdUserHandRaised
@@ -154,9 +163,11 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 			| ActionIdUserWaitingRoom
 			| ActionIdUserWebinar
 			| ActionIdZoomISOEngine
+			| ActionIdZoomISOConfig
 			| ActionIdZoomISOOutputSettings
 			| ActionIdZoomISOActions
 			| ActionIdUsers
+			| ActionIdSocialStream
 			| ActionIdZoomISORouting]: CompanionActionDefinition | undefined
 	} = {
 		...actionsGroups,
@@ -175,82 +186,18 @@ export function GetActions(instance: InstanceBaseExt<ZoomConfig>): CompanionActi
 		...actionUserSharescreen,
 		...actionUserSettings,
 		...actionGlobal,
+		...actionGlobalChat,
 		...actionGlobalBreakoutRooms,
 		...actionGlobalRecording,
 		...actionGlobalWaitingRoomsAndZak,
 		...actionGlobalMemoryManagement,
 		...actionZoomISORouting,
 		...actionZoomISOEngine,
+		...actionZoomISOConfig,
 		...actionZoomISOOutputSettings,
 		...actionZoomISOActions,
 		...actionUsers,
-		[ActionId.loadISOConfig]: {
-			name: 'Load Config',
-			options: [options.path],
-			callback: (action): void => {
-				// type: 'ISO'
-				const command = createCommand(instance, '/loadConfig')
-				command.args.push({ type: 'i', value: action.options.path })
-				const sendToCommand = {
-					id: ActionId.loadISOConfig,
-					options: {
-						command: command.oscPath,
-						args: command.args,
-					},
-				}
-				sendActionCommand(instance, sendToCommand)
-			},
-		},
-		[ActionId.saveISOConfig]: {
-			name: 'Save Config',
-			options: [options.path],
-			callback: (action): void => {
-				// type: 'ISO'
-				const command = createCommand(instance, '/saveConfig')
-				command.args.push({ type: 'i', value: action.options.path })
-				const sendToCommand = {
-					id: ActionId.saveISOConfig,
-					options: {
-						command: command.oscPath,
-						args: command.args,
-					},
-				}
-				sendActionCommand(instance, sendToCommand)
-			},
-		},
-		[ActionId.mergeISOConfig]: {
-			name: 'Merge Config',
-			options: [options.path],
-			callback: (action): void => {
-				// type: 'ISO'
-				const command = createCommand(instance, '/mergeConfig')
-				command.args.push({ type: 'i', value: action.options.path })
-				const sendToCommand = {
-					id: ActionId.mergeISOConfig,
-					options: {
-						command: command.oscPath,
-						args: command.args,
-					},
-				}
-				sendActionCommand(instance, sendToCommand)
-			},
-		},
-		[ActionId.getConfigPath]: {
-			name: 'getConfig path',
-			options: [],
-			callback: (): void => {
-				// type: 'ISO'
-				const command = createCommand(instance, '/getConfigPath')
-				const sendToCommand = {
-					id: ActionId.getConfigPath,
-					options: {
-						command: command.oscPath,
-						args: command.args,
-					},
-				}
-				sendActionCommand(instance, sendToCommand)
-			},
-		},
+		...actionSocialStream,
 		[ActionId.acceptRecordingConsent]: {
 			name: 'Accept Recording Consent',
 			options: [],

--- a/src/actions/action-global-chat.ts
+++ b/src/actions/action-global-chat.ts
@@ -1,0 +1,35 @@
+import { CompanionActionDefinition } from '@companion-module/base'
+import { ZoomConfig } from '../config.js'
+import { InstanceBaseExt, options } from '../utils.js'
+import { createCommand, sendActionCommand } from './action-utils.js'
+
+export enum ActionIdGlobalChat {
+	sendAChatToEveryone = 'sendAChatToEveryone',
+}
+
+export function GetActionsGlobalChat(instance: InstanceBaseExt<ZoomConfig>): {
+	[id in ActionIdGlobalChat]: CompanionActionDefinition | undefined
+} {
+	const actions: { [id in ActionIdGlobalChat]: CompanionActionDefinition | undefined } = {
+		[ActionIdGlobalChat.sendAChatToEveryone]: {
+			name: 'Send A Chat To Everyone',
+			options: [options.message],
+			callback: async (action): Promise<void> => {
+				// type: 'Global'
+				const command = createCommand(instance, '/chatAll')
+				const message = await instance.parseVariablesInString(action.options.message as string)
+				command.args.push({ type: 's', value: message.replaceAll('\\n', '\n') })
+				const sendToCommand = {
+					id: ActionIdGlobalChat.sendAChatToEveryone,
+					options: {
+						command: command.oscPath,
+						args: command.args,
+					},
+				}
+				sendActionCommand(instance, sendToCommand)
+			},
+		},
+	}
+
+	return actions
+}

--- a/src/actions/action-global.ts
+++ b/src/actions/action-global.ts
@@ -24,7 +24,6 @@ export enum ActionIdGlobal {
 	joinMeeting = 'joinMeeting',
 	leaveMeeting = 'leaveMeeting',
 	pingZoomOSC = 'pingZoomOSC',
-	sendAChatToEveryone = 'sendAChatToEveryone',
 	ejectAll = 'ejectAll',
 }
 
@@ -272,24 +271,6 @@ export function GetActionsGlobal(instance: InstanceBaseExt<ZoomConfig>): {
 				const command = createCommand(instance, '/ping')
 				const sendToCommand = {
 					id: ActionIdGlobal.pingZoomOSC,
-					options: {
-						command: command.oscPath,
-						args: command.args,
-					},
-				}
-				sendActionCommand(instance, sendToCommand)
-			},
-		},
-		[ActionIdGlobal.sendAChatToEveryone]: {
-			name: 'Send A Chat To Everyone',
-			options: [options.message],
-			callback: async (action): Promise<void> => {
-				// type: 'Global'
-				const command = createCommand(instance, '/chatAll')
-				const message = await instance.parseVariablesInString(action.options.message as string)
-				command.args.push({ type: 's', value: message.replaceAll('\\n', '\n') })
-				const sendToCommand = {
-					id: ActionIdGlobal.sendAChatToEveryone,
 					options: {
 						command: command.oscPath,
 						args: command.args,

--- a/src/actions/action-social-stream.ts
+++ b/src/actions/action-social-stream.ts
@@ -1,0 +1,87 @@
+import { CompanionActionDefinition } from '@companion-module/base'
+import { ZoomConfig } from '../config.js'
+import { InstanceBaseExt, options } from '../utils.js'
+import { socialStreamApi } from '../socialstream.js'
+
+export enum ActionIdSocialStream {
+	sendAChatToSocialStream = 'sendAChatToSocialStream',
+	turnOnSocialStream = 'turnOnSocialStream',
+	turnOffSocialStream = 'turnOffSocialStream',
+	toggleSocialStream = 'toggleSocialStream',
+}
+
+export function GetActionsSocalSteam(instance: InstanceBaseExt<ZoomConfig>): {
+	[id in ActionIdSocialStream]: CompanionActionDefinition | undefined
+} {
+	const actions: { [id in ActionIdSocialStream]: CompanionActionDefinition | undefined } = {
+		[ActionIdSocialStream.sendAChatToSocialStream]: {
+			name: 'Send A Chat To Social Stream',
+			options: [options.name, options.message],
+			callback: async (action): Promise<void> => {
+				const socialStreamEnabled = instance.config.enableSocialStream
+				if (socialStreamEnabled) {
+					const message = await instance.parseVariablesInString(action.options.message as string)
+					const name = await instance.parseVariablesInString(action.options.name as string)
+					await socialStreamApi.postMessage(name, message, instance)
+					// const socialStreamId = instance.config.socialStreamId
+					// const url = `https://io.socialstream.ninja/${socialStreamId}`
+					// const body = {
+					// 	chatname: name,
+					// 	chatmessage: message,
+					// 	textonly: false,
+					// 	chatimg: null,
+					// 	type: 'zoom',
+					// }
+					// instance.log('debug', url)
+					// const options = {
+					// 	json: body,
+					// 	headers: {
+					// 		'Content-Type': 'application/json',
+					// 	},
+					// }
+					// await got.post(url, options)
+				} else {
+					instance.log('debug', 'Social Stream is not enabled in config')
+				}
+			},
+		},
+		[ActionIdSocialStream.turnOnSocialStream]: {
+			name: 'Turn On Social Stream',
+			options: [],
+			callback: async (): Promise<void> => {
+				const socialStreamEnabled = instance.config.enableSocialStream
+				if (socialStreamEnabled == false) {
+					instance.config.enableSocialStream = true
+					instance.saveConfig(instance.config)
+				}
+			},
+		},
+		[ActionIdSocialStream.turnOffSocialStream]: {
+			name: 'Turn Off Social Stream',
+			options: [],
+			callback: async (): Promise<void> => {
+				const socialStreamEnabled = instance.config.enableSocialStream
+				if (socialStreamEnabled == true) {
+					instance.config.enableSocialStream = false
+					instance.saveConfig(instance.config)
+				}
+			},
+		},
+		[ActionIdSocialStream.toggleSocialStream]: {
+			name: 'Toggle Social Stream On/Off',
+			options: [],
+			callback: async (): Promise<void> => {
+				const socialStreamEnabled = instance.config.enableSocialStream
+				if (socialStreamEnabled == true) {
+					instance.config.enableSocialStream = false
+					instance.saveConfig(instance.config)
+				} else {
+					instance.config.enableSocialStream = true
+					instance.saveConfig(instance.config)
+				}
+			},
+		},
+	}
+
+	return actions
+}

--- a/src/actions/action-social-stream.ts
+++ b/src/actions/action-social-stream.ts
@@ -23,23 +23,6 @@ export function GetActionsSocalSteam(instance: InstanceBaseExt<ZoomConfig>): {
 					const message = await instance.parseVariablesInString(action.options.message as string)
 					const name = await instance.parseVariablesInString(action.options.name as string)
 					await socialStreamApi.postMessage(name, message, instance)
-					// const socialStreamId = instance.config.socialStreamId
-					// const url = `https://io.socialstream.ninja/${socialStreamId}`
-					// const body = {
-					// 	chatname: name,
-					// 	chatmessage: message,
-					// 	textonly: false,
-					// 	chatimg: null,
-					// 	type: 'zoom',
-					// }
-					// instance.log('debug', url)
-					// const options = {
-					// 	json: body,
-					// 	headers: {
-					// 		'Content-Type': 'application/json',
-					// 	},
-					// }
-					// await got.post(url, options)
 				} else {
 					instance.log('debug', 'Social Stream is not enabled in config')
 				}

--- a/src/actions/action-zoomiso-config.ts
+++ b/src/actions/action-zoomiso-config.ts
@@ -1,0 +1,87 @@
+import { CompanionActionDefinition } from '@companion-module/base'
+import { ZoomConfig } from '../config.js'
+import { InstanceBaseExt, options } from '../utils.js'
+import { createCommand, sendActionCommand } from './action-utils.js'
+
+export enum ActionIdZoomISOConfig {
+	loadISOConfig = 'load_ISO_Config',
+	saveISOConfig = 'save_ISO_Config',
+	mergeISOConfig = 'merge_ISO_Config',
+	getConfigPath = 'get_Config_Path',
+}
+
+export function GetActionsZoomISOConfig(instance: InstanceBaseExt<ZoomConfig>): {
+	[id in ActionIdZoomISOConfig]: CompanionActionDefinition | undefined
+} {
+	const actions: { [id in ActionIdZoomISOConfig]: CompanionActionDefinition | undefined } = {
+		[ActionIdZoomISOConfig.loadISOConfig]: {
+			name: 'Load Config',
+			options: [options.path],
+			callback: (action): void => {
+				// type: 'ISO'
+				const command = createCommand(instance, '/loadConfig')
+				command.args.push({ type: 'i', value: action.options.path })
+				const sendToCommand = {
+					id: ActionIdZoomISOConfig.loadISOConfig,
+					options: {
+						command: command.oscPath,
+						args: command.args,
+					},
+				}
+				sendActionCommand(instance, sendToCommand)
+			},
+		},
+		[ActionIdZoomISOConfig.saveISOConfig]: {
+			name: 'Save Config',
+			options: [options.path],
+			callback: (action): void => {
+				// type: 'ISO'
+				const command = createCommand(instance, '/saveConfig')
+				command.args.push({ type: 'i', value: action.options.path })
+				const sendToCommand = {
+					id: ActionIdZoomISOConfig.saveISOConfig,
+					options: {
+						command: command.oscPath,
+						args: command.args,
+					},
+				}
+				sendActionCommand(instance, sendToCommand)
+			},
+		},
+		[ActionIdZoomISOConfig.mergeISOConfig]: {
+			name: 'Merge Config',
+			options: [options.path],
+			callback: (action): void => {
+				// type: 'ISO'
+				const command = createCommand(instance, '/mergeConfig')
+				command.args.push({ type: 'i', value: action.options.path })
+				const sendToCommand = {
+					id: ActionIdZoomISOConfig.mergeISOConfig,
+					options: {
+						command: command.oscPath,
+						args: command.args,
+					},
+				}
+				sendActionCommand(instance, sendToCommand)
+			},
+		},
+		[ActionIdZoomISOConfig.getConfigPath]: {
+			name: 'getConfig path',
+			options: [],
+			callback: (): void => {
+				// type: 'ISO'
+				const command = createCommand(instance, '/getConfigPath')
+				const sendToCommand = {
+					id: ActionIdZoomISOConfig.getConfigPath,
+					options: {
+						command: command.oscPath,
+						args: command.args,
+					},
+				}
+				sendActionCommand(instance, sendToCommand)
+			},
+		},
+	}
+
+	return actions
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,8 @@ export interface ZoomConfig {
 	numberOfGroups: number
 	pulling: number
 	feedbackImagesWithIcons: number
+	enableSocialStream: boolean
+	socialStreamId: string
 }
 
 export const GetConfigFields = (): SomeCompanionConfigField[] => {
@@ -61,17 +63,6 @@ export const GetConfigFields = (): SomeCompanionConfigField[] => {
 			default: 1,
 			width: 6,
 		},
-		// {
-		// 	type: 'dropdown',
-		// 	id: 'version',
-		// 	label: 'Using ZoomOSC or ZoomISO',
-		// 	choices: [
-		// 		{ id: ZoomVersion.ZoomISO, label: 'ZoomISO' },
-		// 		{ id: ZoomVersion.ZoomOSC, label: 'ZoomOSC' },
-		// 	],
-		// 	default: ZoomVersion.ZoomOSC,
-		// 	width: 6,
-		// },
 		{
 			type: 'dropdown',
 			id: 'pulling',
@@ -98,6 +89,7 @@ export const GetConfigFields = (): SomeCompanionConfigField[] => {
 			type: 'dropdown',
 			id: 'feedbackImagesWithIcons',
 			label: 'Participant Multi-State Feedback Design',
+			tooltip: 'Adds icons to button for camera, mic, and hand raised state',
 			choices: [
 				{ id: 0, label: 'Bottom (On and Off For Mic/Camera, Only on for Hand Raise)' },
 				{ id: 2, label: 'Bottom (Only Active States)' },
@@ -114,6 +106,22 @@ export const GetConfigFields = (): SomeCompanionConfigField[] => {
 				'If you are using the lite version of ZoomOSC or ZoomISO, some core functionality like the gallery tracking will not work as it requires commands that are only available in the PRO version and ZoomISO is limitged to a maximum of 4 outputs.  As well, only the actions that are not listed as PRO in the <a target="_blank" href="https://www.liminalet.com/zoomosc-resources">ZoomOSC API/Command List</a> and the <a target="_blank" href="https://www.liminalet.com/zoomiso">ZoomISO Documentation (User Guide)</a> work with the lite version',
 			id: 'liteNote',
 			label: 'If You Are Using The Lite Version',
+		},
+		{
+			type: 'checkbox',
+			id: 'enableSocialStream',
+			width: 12,
+			default: false,
+			label: 'Enable Social Stream for Chat',
+			tooltip: 'Sent all Chat Message to Social Stream Ninja',
+		},
+		{
+			type: 'textinput',
+			id: 'socialStreamId',
+			label: 'Session Id for Social Stream',
+			width: 12,
+			default: '',
+			isVisible: (options) => options['enableSocialStream'] === true,
 		},
 	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ class ZoomInstance extends InstanceBase<ZoomConfig> {
 		numberOfGroups: 0,
 		pulling: 0,
 		feedbackImagesWithIcons: 1,
+		enableSocialStream: false,
+		socialStreamId: '',
 	}
 
 	// Global call settings

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -455,7 +455,11 @@ export class OSC {
 							}
 							case 'chat':
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))
-								if (data.args.length >= 5) {
+								if (
+									this.instance.config.enableSocialStream &&
+									this.instance.config.socialStreamId.length > 0 &&
+									data.args.length >= 5
+								) {
 									await socialStreamApi.postMessage(data.args[1].value, data.args[4].value, this.instance)
 								}
 								break

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -3,6 +3,7 @@ import { InstanceStatus, OSCSomeArguments } from '@companion-module/base'
 import { ZoomConfig } from './config.js'
 import { FeedbackId } from './feedback.js'
 import { PreviousSelectedCallersRestore, PreviousSelectedCallersSave } from './actions/action-utils.js'
+import { socialStreamApi } from './socialstream.js'
 const osc = require('osc') // eslint-disable-line
 
 interface ZoomOSCResponse {
@@ -454,6 +455,9 @@ export class OSC {
 							}
 							case 'chat':
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))
+								if (data.args.length >= 5) {
+									await socialStreamApi.postMessage(data.args[1].value, data.args[4].value, this.instance)
+								}
 								break
 							case 'audioStatus':
 								// this.instance.log('info', 'receiving:' + JSON.stringify(data))

--- a/src/presets/preset-chat.ts
+++ b/src/presets/preset-chat.ts
@@ -1,7 +1,7 @@
 import { ActionIdUserChat } from '../actions/action-user-chat.js'
 import { colorBlack, colorLightGray } from '../utils.js'
 import { CompanionPresetDefinitionsExt } from './preset-utils.js'
-import { ActionIdGlobal } from '../actions/action-global.js'
+import { ActionIdGlobalChat } from '../actions/action-global-chat.js'
 
 export function GetPresetsChat(): CompanionPresetDefinitionsExt {
 	const presets: CompanionPresetDefinitionsExt = {}
@@ -22,7 +22,7 @@ export function GetPresetsChat(): CompanionPresetDefinitionsExt {
 			{
 				down: [
 					{
-						actionId: ActionIdGlobal.sendAChatToEveryone,
+						actionId: ActionIdGlobalChat.sendAChatToEveryone,
 						options: {},
 					},
 				],

--- a/src/presets/preset-utils.ts
+++ b/src/presets/preset-utils.ts
@@ -14,6 +14,7 @@ import { ActionIdGlobalGalleryTrackingAndDataRequest } from '../actions/action-g
 import { ActionIdGlobalRecording } from '../actions/action-global-recording.js'
 import { ActionIdGlobalWaitingRoomsAndZak } from '../actions/action-global-waitingrooms-and-zak.js'
 import { ActionIdGlobal } from '../actions/action-global.js'
+import { ActionIdGlobalChat } from '../actions/action-global-chat.js'
 import { ActionIdUserBreakoutRooms } from '../actions/action-user-breakout-rooms.js'
 import { ActionIdUserChat } from '../actions/action-user-chat.js'
 import { ActionIdUserHandRaised } from '../actions/action-user-hand-raised.js'
@@ -27,6 +28,7 @@ import { ActionIdUserView } from '../actions/action-user-view.js'
 import { ActionIdUserWaitingRoom } from '../actions/action-user-waiting-room.js'
 import { ActionIdUserWebinar } from '../actions/action-user-webinars.js'
 import { ActionIdZoomISOEngine } from '../actions/action-zoomiso-engine.js'
+import { ActionIdZoomISOConfig } from '../actions/action-zoomiso-config.js'
 import { ActionIdZoomISOOutputSettings } from '../actions/action-zoomiso-output-settings.js'
 import { ActionIdZoomISORouting } from '../actions/action-zoomiso-routing.js'
 import { ActionIdZoomISOActions } from '../actions/action-zoomiso-actions.js'
@@ -54,6 +56,7 @@ export interface CompanionPresetExt extends CompanionButtonPresetDefinition {
 					| ActionIdGlobalRecording
 					| ActionIdGlobalWaitingRoomsAndZak
 					| ActionIdGlobal
+					| ActionIdGlobalChat
 					| ActionIdUserBreakoutRooms
 					| ActionIdUserChat
 					| ActionIdUserHandRaised
@@ -67,6 +70,7 @@ export interface CompanionPresetExt extends CompanionButtonPresetDefinition {
 					| ActionIdUserWaitingRoom
 					| ActionIdUserWebinar
 					| ActionIdZoomISOEngine
+					| ActionIdZoomISOConfig
 					| ActionIdZoomISOOutputSettings
 					| ActionIdZoomISORouting
 					| ActionIdZoomISOActions
@@ -85,6 +89,7 @@ export interface CompanionPresetExt extends CompanionButtonPresetDefinition {
 					| ActionIdGlobalRecording
 					| ActionIdGlobalWaitingRoomsAndZak
 					| ActionIdGlobal
+					| ActionIdGlobalChat
 					| ActionIdUserBreakoutRooms
 					| ActionIdUserChat
 					| ActionIdUserHandRaised
@@ -98,6 +103,7 @@ export interface CompanionPresetExt extends CompanionButtonPresetDefinition {
 					| ActionIdUserWaitingRoom
 					| ActionIdUserWebinar
 					| ActionIdZoomISOEngine
+					| ActionIdZoomISOConfig
 					| ActionIdZoomISOOutputSettings
 					| ActionIdZoomISORouting
 					| ActionIdZoomISOActions

--- a/src/socialstream.ts
+++ b/src/socialstream.ts
@@ -4,8 +4,13 @@ import { ZoomConfig } from './config.js'
 
 export class socialStreamApi {
 	static postMessage = async (name: string, message: string, instance: InstanceBaseExt<ZoomConfig>): Promise<void> => {
-		if (instance.config.enableSocialStream) {
-			// instance.log('debug', `chat -- ${name} - ${message}`)
+		if (
+			instance.config.enableSocialStream &&
+			instance.config.socialStreamId.length > 0 &&
+			message.length > 0 &&
+			name.length > 0
+		) {
+			instance.log('debug', `chat -- ${name} - ${message}`)
 			const socialStreamId = instance.config.socialStreamId
 			const url = `https://io.socialstream.ninja/${socialStreamId}`
 			const body = {

--- a/src/socialstream.ts
+++ b/src/socialstream.ts
@@ -1,0 +1,27 @@
+import got from 'got-cjs'
+import { InstanceBaseExt } from './utils.js'
+import { ZoomConfig } from './config.js'
+
+export class socialStreamApi {
+	static postMessage = async (name: string, message: string, instance: InstanceBaseExt<ZoomConfig>): Promise<void> => {
+		if (instance.config.enableSocialStream) {
+			// instance.log('debug', `chat -- ${name} - ${message}`)
+			const socialStreamId = instance.config.socialStreamId
+			const url = `https://io.socialstream.ninja/${socialStreamId}`
+			const body = {
+				chatname: name,
+				chatmessage: message,
+				textonly: false,
+				chatimg: null,
+				type: 'zoom',
+			}
+			const options = {
+				json: body,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			}
+			await got.post(url, options)
+		}
+	}
+}

--- a/src/v2CommandsToUpgradeTov3.ts
+++ b/src/v2CommandsToUpgradeTov3.ts
@@ -16,11 +16,13 @@ import { ActionIdUserWaitingRoom } from './actions/action-user-waiting-room.js'
 import { ActionIdUserScreenshare } from './actions/action-user-screenshare.js'
 import { ActionIdUserSettings } from './actions/action-user-settings.js'
 import { ActionIdGlobal } from './actions/action-global.js'
+import { ActionIdGlobalChat } from './actions/action-global-chat.js'
 import { ActionIdGlobalBreakoutRooms } from './actions/action-global-breakout-rooms.js'
 import { ActionIdGlobalRecording } from './actions/action-global-recording.js'
 import { ActionIdGlobalWaitingRoomsAndZak } from './actions/action-global-waitingrooms-and-zak.js'
 import { ActionIdGlobalMemoryManagement } from './actions/action-global-memory-management.js'
 import { ActionIdZoomISORouting } from './actions/action-zoomiso-routing.js'
+import { ActionIdZoomISOConfig } from './actions/action-zoomiso-config.js'
 import { ActionIdZoomISOEngine } from './actions/action-zoomiso-engine.js'
 import { ActionIdZoomISOOutputSettings } from './actions/action-zoomiso-output-settings.js'
 import { ActionIdZoomISOActions } from './actions/action-zoomiso-actions.js'
@@ -558,7 +560,7 @@ export const v2Actions: v2Action = {
 	},
 	SendAChatToEveryone: {
 		oldActionId: 'SendAChatToEveryone',
-		newActionId: ActionIdGlobal.sendAChatToEveryone,
+		newActionId: ActionIdGlobalChat.sendAChatToEveryone,
 		type: 'GlobalActions',
 	},
 	CreateBreakoutRoom: {
@@ -708,22 +710,22 @@ export const v2Actions: v2Action = {
 	},
 	loadISOConfig: {
 		oldActionId: 'loadISOConfig',
-		newActionId: ActionId.loadISOConfig,
+		newActionId: ActionIdZoomISOConfig.loadISOConfig,
 		type: 'ISOActions',
 	},
 	saveISOConfig: {
 		oldActionId: 'saveISOConfig',
-		newActionId: ActionId.saveISOConfig,
+		newActionId: ActionIdZoomISOConfig.saveISOConfig,
 		type: 'ISOActions',
 	},
 	mergeISOConfig: {
 		oldActionId: 'mergeISOConfig',
-		newActionId: ActionId.mergeISOConfig,
+		newActionId: ActionIdZoomISOConfig.mergeISOConfig,
 		type: 'ISOActions',
 	},
 	getConfigPath: {
 		oldActionId: 'getConfigPath',
-		newActionId: ActionId.getConfigPath,
+		newActionId: ActionIdZoomISOConfig.getConfigPath,
 		type: 'ISOActions',
 	},
 	setOutputMode: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@companion-module/base@~1.7.0":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@companion-module/base/-/base-1.7.1.tgz#3f054a78a6f48382bd17522c0633691dc96deb93"
-  integrity sha512-DDgSzqNr9xW/d85yoSOy85Iutw1UaqwmOMw1gLdX7/BsPYE/pHl8JzrUuio0MazPRvYbGGTchqxt5Mq3r67izg==
+"@companion-module/base@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@companion-module/base/-/base-1.8.0.tgz#1c74204b29451bd7740b2428db372fdfaf51d84d"
+  integrity sha512-97qmnaPAJZbisYR6EBQ/fZxY8dPLV3my6qIHJzifFl/vkwi+a3ucoXQWLwd5tijM9pqbZOS/3b2V1m6sbdAWlQ==
   dependencies:
-    "@sentry/node" "^7.82.0"
-    "@sentry/tracing" "^7.82.0"
+    "@sentry/node" "^7.109.0"
+    "@sentry/tracing" "^7.109.0"
     ajv "^8.12.0"
     colord "^2.9.3"
     ejson "^2.2.3"
@@ -19,7 +19,7 @@
     p-timeout "^4.1.0"
     tslib "^2.6.2"
 
-"@companion-module/tools@^1.4.2":
+"@companion-module/tools@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@companion-module/tools/-/tools-1.5.0.tgz#ce3cc1fc8aa71ebcbb8fcc65ccaad22099bb3c9e"
   integrity sha512-J9sY2DE6i7bWYZ1uoPE8Drux53StYVqpVe+xHF0mERvV9QXOvPQ5AqxM12ts/Jd0vzd94jqLEUzm1I/y/KEWtw==
@@ -172,62 +172,91 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@sentry-internal/tracing@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.112.2.tgz#83460e51875ddb160c060bfee2e21833117f259c"
-  integrity sha512-fT1Y46J4lfXZkgFkb03YMNeIEs2xS6jdKMoukMFQfRfVvL9fSWEbTgZpHPd/YTT8r2i082XzjtAoQNgklm/0Hw==
+"@sentry-internal/tracing@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.114.0.tgz#bdcd364f511e2de45db6e3004faf5685ca2e0f86"
+  integrity sha512-dOuvfJN7G+3YqLlUY4HIjyWHaRP8vbOgF+OsE5w2l7ZEn1rMAaUbPntAR8AF9GBA6j2zWNoSo8e7GjbJxVofSg==
   dependencies:
-    "@sentry/core" "7.112.2"
-    "@sentry/types" "7.112.2"
-    "@sentry/utils" "7.112.2"
+    "@sentry/core" "7.114.0"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
 
-"@sentry/core@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.112.2.tgz#d2e6d2acb6947fcb384298a3bd2b0c8183533dd8"
-  integrity sha512-gHPCcJobbMkk0VR18J65WYQTt3ED4qC6X9lHKp27Ddt63E+MDGkG6lvYBU1LS8cV7CdyBGC1XXDCfor61GvLsA==
+"@sentry-internal/tracing@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.116.0.tgz#af3e4e264c440aa5525b5877a10b9a0f870b40e3"
+  integrity sha512-y5ppEmoOlfr77c/HqsEXR72092qmGYS4QE5gSz5UZFn9CiinEwGfEorcg2xIrrCuU7Ry/ZU2VLz9q3xd04drRA==
   dependencies:
-    "@sentry/types" "7.112.2"
-    "@sentry/utils" "7.112.2"
+    "@sentry/core" "7.116.0"
+    "@sentry/types" "7.116.0"
+    "@sentry/utils" "7.116.0"
 
-"@sentry/integrations@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.112.2.tgz#2aad01719b1e4a1326f42db78f77fcf1e58d4c63"
-  integrity sha512-ioC2yyU6DqtLkdmWnm87oNvdn2+9oKctJeA4t+jkS6JaJ10DcezjCwiLscX4rhB9aWJV3IWF7Op0O6K3w0t2Hg==
+"@sentry/core@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.114.0.tgz#3efe86b92a5379c44dfd0fd4685266b1a30fa898"
+  integrity sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==
   dependencies:
-    "@sentry/core" "7.112.2"
-    "@sentry/types" "7.112.2"
-    "@sentry/utils" "7.112.2"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+
+"@sentry/core@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.116.0.tgz#7cff43134878a696b2b3b981ae384ec3db9ac8c3"
+  integrity sha512-J6Wmjjx+o7RwST0weTU1KaKUAlzbc8MGkJV1rcHM9xjNTWTva+nrcCM3vFBagnk2Gm/zhwv3h0PvWEqVyp3U1Q==
+  dependencies:
+    "@sentry/types" "7.116.0"
+    "@sentry/utils" "7.116.0"
+
+"@sentry/integrations@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.116.0.tgz#b641342249da76cd2feb2fb5511424b66f967449"
+  integrity sha512-UZb60gaF+7veh1Yv79RiGvgGYOnU6xA97H+hI6tKgc1uT20YpItO4X56Vhp0lvyEyUGFZzBRRH1jpMDPNGPkqw==
+  dependencies:
+    "@sentry/core" "7.116.0"
+    "@sentry/types" "7.116.0"
+    "@sentry/utils" "7.116.0"
     localforage "^1.8.1"
 
-"@sentry/node@^7.82.0":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.112.2.tgz#9b7378004ed5aef13dbfc8ccc55b06be627eb947"
-  integrity sha512-MNzkqER8jc2xOS3ArkCLH5hakzu15tcjeC7qjU7rQ1Ms4WuV+MG0docSRESux0/p23Qjzf9tZOc8C5Eq+Sxduw==
+"@sentry/node@^7.109.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.116.0.tgz#199c304e203f35ca0e814fb7fc8a9b3f30b2c612"
+  integrity sha512-HB/4TrJWbnu6swNzkid+MlwzLwY/D/klGt3R0aatgrgWPo2jJm6bSl4LUT39Cr2eg5I1gsREQtXE2mAlC6gm8w==
   dependencies:
-    "@sentry-internal/tracing" "7.112.2"
-    "@sentry/core" "7.112.2"
-    "@sentry/integrations" "7.112.2"
-    "@sentry/types" "7.112.2"
-    "@sentry/utils" "7.112.2"
+    "@sentry-internal/tracing" "7.116.0"
+    "@sentry/core" "7.116.0"
+    "@sentry/integrations" "7.116.0"
+    "@sentry/types" "7.116.0"
+    "@sentry/utils" "7.116.0"
 
-"@sentry/tracing@^7.82.0":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.112.2.tgz#719bd07f898f2fca0d015240d07eb9bd1d7022d2"
-  integrity sha512-Dw641xm7seI+f3SAbKmSi6RNIpsLPrNPxPQbUhJpfDmJQOY6Rl00XANKAwW+QEiSqukGko1Evo3kU1NDxVmRgA==
+"@sentry/tracing@^7.109.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.114.0.tgz#32a3438b0f2d02fb7b7359fe7712c5a349a2a329"
+  integrity sha512-eldEYGADReZ4jWdN5u35yxLUSTOvjsiZAYd4KBEpf+Ii65n7g/kYOKAjNl7tHbrEG1EsMW4nDPWStUMk1w+tfg==
   dependencies:
-    "@sentry-internal/tracing" "7.112.2"
+    "@sentry-internal/tracing" "7.114.0"
 
-"@sentry/types@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.112.2.tgz#71ff27c668309ccd8d17b7793e044e46f81eca1b"
-  integrity sha512-kCMLt7yhY5OkWE9MeowlTNmox9pqDxcpvqguMo4BDNZM5+v9SEb1AauAdR78E1a1V8TyCzjBD7JDfXWhvpYBcQ==
+"@sentry/types@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.114.0.tgz#ab8009d5f6df23b7342121083bed34ee2452e856"
+  integrity sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==
 
-"@sentry/utils@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.112.2.tgz#223f9feee5860459792a43904db4bf38fba73ed3"
-  integrity sha512-OjLh0hx0t1EcL4ZIjf+4svlmmP+tHUDGcr5qpFWH78tjmkPW4+cqPuZCZfHSuWcDdeiaXi8TnYoVRqDcJKK/eQ==
+"@sentry/types@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.116.0.tgz#0be3434e7e53c86db4993e668af1c3a65bfb7519"
+  integrity sha512-QCCvG5QuQrwgKzV11lolNQPP2k67Q6HHD9vllZ/C4dkxkjoIym8Gy+1OgAN3wjsR0f/kG9o5iZyglgNpUVRapQ==
+
+"@sentry/utils@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.114.0.tgz#59d30a79f4acff3c9268de0b345f0bcbc6335112"
+  integrity sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==
   dependencies:
-    "@sentry/types" "7.112.2"
+    "@sentry/types" "7.114.0"
+
+"@sentry/utils@7.116.0":
+  version "7.116.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.116.0.tgz#f32463ab10f76f464274233a9df202e5357d17ff"
+  integrity sha512-Vn9fcvwTq91wJvCd7WTMWozimqMi+dEZ3ie3EICELC2diONcN16ADFdzn65CQQbYwmUzRjN9EjDN2k41pKZWhQ==
+  dependencies:
+    "@sentry/types" "7.116.0"
 
 "@serialport/binding-mock@10.2.2":
   version "10.2.2"
@@ -313,6 +342,18 @@
     "@serialport/bindings-interface" "1.2.2"
     debug "^4.3.2"
 
+"@sindresorhus/is@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
+"@szmarczak/http-timer@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
+  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -341,6 +382,15 @@
   dependencies:
     "@types/jsonfile" "*"
     "@types/node" "*"
+
+"@types/got@^9.6.12":
+  version "9.6.12"
+  resolved "https://registry.yarnpkg.com/@types/got/-/got-9.6.12.tgz#fd42a6e1f5f64cd6bb422279b08c30bb5a15a56f"
+  integrity sha512-X4pj/HGHbXVLqTpKjA2ahI4rV/nNBc9mGO2I/0CgAra+F2dKgMXnENv2SRpemScBzBAI4vMelIVYViQxlSE6xA==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
@@ -378,10 +428,22 @@
   resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.6.tgz#fbb22dabe3d64b79295f37ce0afb7320a26ac9a6"
   integrity sha512-PtrlVaOaI44/3pl3cvnlK+GxOM3re2526TJvPvh7W+keHIXdV4TE0ylpPBAcvFQCbGitaTXwL9u+RF7qtVeazQ==
 
+"@types/responselike@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/semver@^7.3.12":
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/which@^3.0.0":
   version "3.0.3"
@@ -700,6 +762,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 author-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
@@ -759,6 +826,24 @@ builtins@^5.0.1:
   dependencies:
     semver "^7.0.0"
 
+cacheable-lookup@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz#0330a543471c61faa4e9035db583aad753b36385"
+  integrity sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==
+
+cacheable-request@7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
+  integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^6.0.1"
+    responselike "^2.0.0"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -816,6 +901,13 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clone-response@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
+  integrity sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==
+  dependencies:
+    mimic-response "^1.0.0"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -837,6 +929,13 @@ colorette@^2.0.14, colorette@^2.0.20:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
+combined-stream@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 commander@11.1.0:
   version "11.1.0"
@@ -879,10 +978,27 @@ debug@4.3.4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+defer-to-connect@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -932,6 +1048,13 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@^5.16.0:
   version "5.16.0"
@@ -1269,6 +1392,20 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
+form-data-encoder@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
+  integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 formdata-polyfill@^4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
@@ -1316,6 +1453,18 @@ get-east-asian-width@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz#5e6ebd9baee6fb8b7b6bd505221065f0cd91f64e"
   integrity sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==
+
+get-stream@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  dependencies:
+    pump "^3.0.0"
+
+get-stream@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-stream@^8.0.1:
   version "8.0.1"
@@ -1401,6 +1550,24 @@ globby@^13.1.4:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
+got-cjs@^12.5.4:
+  version "12.5.4"
+  resolved "https://registry.yarnpkg.com/got-cjs/-/got-cjs-12.5.4.tgz#b46419c0e8e5fb5503b926941807408049ae2e11"
+  integrity sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==
+  dependencies:
+    "@sindresorhus/is" "4.6.0"
+    "@szmarczak/http-timer" "4.0.6"
+    "@types/responselike" "1.0.0"
+    cacheable-lookup "6.1.0"
+    cacheable-request "7.0.2"
+    decompress-response "^6.0.0"
+    form-data-encoder "1.7.2"
+    get-stream "^6.0.1"
+    http2-wrapper "^2.1.10"
+    lowercase-keys "2.0.0"
+    p-cancelable "2.1.1"
+    responselike "2.0.1"
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -1422,6 +1589,19 @@ hasown@^2.0.0:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+http-cache-semantics@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
+
+http2-wrapper@^2.1.10:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-2.2.1.tgz#310968153dcdedb160d8b72114363ef5fce1f64a"
+  integrity sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.2.0"
 
 human-signals@^5.0.0:
   version "5.0.0"
@@ -1616,7 +1796,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-keyv@^4.5.3:
+keyv@^4.0.0, keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
@@ -1730,6 +1910,11 @@ long@4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+lowercase-keys@2.0.0, lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+
 lru-cache@^10.2.0:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
@@ -1770,7 +1955,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27:
+mime-types@^2.1.12, mime-types@^2.1.27:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -1791,6 +1976,16 @@ mimic-fn@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
+mimic-response@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -1895,6 +2090,11 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
 npm-run-path@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
@@ -1902,7 +2102,7 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -1946,6 +2146,11 @@ osc@^2.4.3:
     ws "8.13.0"
   optionalDependencies:
     serialport "10.5.0"
+
+p-cancelable@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
+  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -2129,6 +2334,14 @@ ps-tree@^1.2.0:
   dependencies:
     event-stream "=3.3.4"
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -2138,6 +2351,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -2157,6 +2375,11 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+resolve-alpn@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -2188,6 +2411,13 @@ resolve@^1.20.0, resolve@^1.22.2:
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+responselike@2.0.1, responselike@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.1.tgz#9a0bc8fdc252f3fb1cca68b016591059ba1422bc"
+  integrity sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^4.0.0:
   version "4.0.0"
@@ -2368,7 +2598,16 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2395,7 +2634,14 @@ string-width@^7.0.0:
     get-east-asian-width "^1.0.0"
     strip-ansi "^7.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@companion-module/base@~1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@companion-module/base/-/base-1.8.0.tgz#1c74204b29451bd7740b2428db372fdfaf51d84d"
-  integrity sha512-97qmnaPAJZbisYR6EBQ/fZxY8dPLV3my6qIHJzifFl/vkwi+a3ucoXQWLwd5tijM9pqbZOS/3b2V1m6sbdAWlQ==
+"@companion-module/base@~1.7.0":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@companion-module/base/-/base-1.7.1.tgz#3f054a78a6f48382bd17522c0633691dc96deb93"
+  integrity sha512-DDgSzqNr9xW/d85yoSOy85Iutw1UaqwmOMw1gLdX7/BsPYE/pHl8JzrUuio0MazPRvYbGGTchqxt5Mq3r67izg==
   dependencies:
-    "@sentry/node" "^7.109.0"
-    "@sentry/tracing" "^7.109.0"
+    "@sentry/node" "^7.82.0"
+    "@sentry/tracing" "^7.82.0"
     ajv "^8.12.0"
     colord "^2.9.3"
     ejson "^2.2.3"
@@ -19,7 +19,7 @@
     p-timeout "^4.1.0"
     tslib "^2.6.2"
 
-"@companion-module/tools@^1.5.0":
+"@companion-module/tools@^1.4.2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@companion-module/tools/-/tools-1.5.0.tgz#ce3cc1fc8aa71ebcbb8fcc65ccaad22099bb3c9e"
   integrity sha512-J9sY2DE6i7bWYZ1uoPE8Drux53StYVqpVe+xHF0mERvV9QXOvPQ5AqxM12ts/Jd0vzd94jqLEUzm1I/y/KEWtw==
@@ -216,7 +216,7 @@
     "@sentry/utils" "7.116.0"
     localforage "^1.8.1"
 
-"@sentry/node@^7.109.0":
+"@sentry/node@^7.82.0":
   version "7.116.0"
   resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.116.0.tgz#199c304e203f35ca0e814fb7fc8a9b3f30b2c612"
   integrity sha512-HB/4TrJWbnu6swNzkid+MlwzLwY/D/klGt3R0aatgrgWPo2jJm6bSl4LUT39Cr2eg5I1gsREQtXE2mAlC6gm8w==
@@ -227,7 +227,7 @@
     "@sentry/types" "7.116.0"
     "@sentry/utils" "7.116.0"
 
-"@sentry/tracing@^7.109.0":
+"@sentry/tracing@^7.82.0":
   version "7.114.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.114.0.tgz#32a3438b0f2d02fb7b7359fe7712c5a349a2a329"
   integrity sha512-eldEYGADReZ4jWdN5u35yxLUSTOvjsiZAYd4KBEpf+Ii65n7g/kYOKAjNl7tHbrEG1EsMW4nDPWStUMk1w+tfg==


### PR DESCRIPTION
## New Feature:

Send chat messages received from ZoomOSC/ISO to Social Stream Ninja.  This is an opt-in feature and requires your social stream session id.

There is also actions to turn on social stream, turn off social stream, toggle social stream, and send a fake message to social stream.  The fake message is useful for things like asking questions in the chat that you want to then highlight.

## Test Out This Feature

If you would like to test out this feature on your Companion v3 build then you can download the attached zip file.  Once you have the zip file then unzip this onto your Companion v3 computer, then click on the little cog in the upper right corner of the Companion GUI, then click the Select button for the Developer Modules path, and select the companion-module-test folder that is in the unzipped directory.  You should now be able to then test out the changes for social stream ninja on your machine without needing to install a new Companion release.

### Revert back to the built-in module after testing

If you want to revert back to the built-in version of the Companion module, click the little cog in the upper right again and it will restart Companion and use the built-in modules.

[companion-module-test.zip](https://github.com/user-attachments/files/15527464/companion-module-test.zip)

