### PR TITLE
update: Zak start and join to support variables

### DIFF
--- a/src/actions/action-global-waitingrooms-and-zak.ts
+++ b/src/actions/action-global-waitingrooms-and-zak.ts
@@ -88,8 +88,10 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 				// type: 'Special'
 				const command = createCommand(instance, '/zakJoin')
 				const newName = await instance.parseVariablesInString(action.options.name as string)
-				command.args.push({ type: 's', value: action.options.zak })
-				command.args.push({ type: 's', value: action.options.meetingID })
+				const zak = await instance.parseVariablesInString(action.options.zak as string)
+				const meetingId = await instance.parseVariablesInString(action.options.meetingID as string)
+				command.args.push({ type: 's', value: zak })
+				command.args.push({ type: 's', value: meetingId })
 				command.args.push({ type: 's', value: newName })
 				const sendToCommand = {
 					id: ActionIdGlobalWaitingRoomsAndZak.ZAKJoinMeeting,
@@ -108,8 +110,10 @@ export function GetActionsGlobalWaitingRoomsAndZak(instance: InstanceBaseExt<Zoo
 				// type: 'Special'
 				const command = createCommand(instance, '/zakStart')
 				const newName = await instance.parseVariablesInString(action.options.name as string)
-				command.args.push({ type: 's', value: action.options.zak })
-				command.args.push({ type: 's', value: action.options.meetingID })
+				const zak = await instance.parseVariablesInString(action.options.zak as string)
+				const meetingId = await instance.parseVariablesInString(action.options.meetingID as string)
+				command.args.push({ type: 's', value: zak })
+				command.args.push({ type: 's', value: meetingId })
 				command.args.push({ type: 's', value: newName })
 				const sendToCommand = {
 					id: ActionIdGlobalWaitingRoomsAndZak.ZAKStartMeeting,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,6 +215,7 @@ export const options: Options = {
 	},
 	meetingID: {
 		type: 'textinput',
+		useVariables: true,
 		label: 'Meeting ID',
 		id: 'meetingID',
 		default: '',
@@ -308,6 +309,7 @@ export const options: Options = {
 	},
 	zak: {
 		type: 'textinput',
+		useVariables: true,
 		label: 'Zak',
 		id: 'zak',
 		default: '',


### PR DESCRIPTION
## New Feature:

Add the ability to use variables for the Zak Token and MeetingId when joining or starting a meeting using ZAK tokens.

## Test Out This Feature

If you would like to test out this feature on your Companion v3 build then you can download the attached zip file.  Once you have the zip file then unzip this onto your Companion v3 computer, then click on the little cog in the upper right corner of the Companion GUI, then click the Select button for the Developer Modules path, and select the companion-module-test folder that is in the unzipped directory.  You should now be able to then test out the changes on your machine without needing to install a new Companion release.

### Revert back to the built-in module after testing

If you want to revert back to the built-in version of the Companion module, click the little cog in the upper right again and it will restart Companion and use the built-in modules.

[companion-module-test.zip](https://github.com/user-attachments/files/15754001/companion-module-test.zip)

fixes #179 