### PR TITLE
fix: password not allowing variables, meetingStatus, and gallery being cleared with empty array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zoom-osc-iso",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"main": "dist/index.js",
 	"repository": {
 		"type": "git",

--- a/src/actions/action-user-pin.ts
+++ b/src/actions/action-user-pin.ts
@@ -5,14 +5,13 @@ import { createCommand, select, sendActionCommand } from './action-utils.js'
 
 export enum ActionIdUserPin {
 	pin = 'pin',
-	addPin = 'add_Pin',
-	unpin = 'unpin',
-	pinScreen2 = 'pin_Screen2',
-	unPinScreen2 = 'unPinScreen2',
-	clearPinsScreen2 = 'clearPinsScreen2',
-	togglePin = 'toggle_Pin',
-	togglePinScreen2 = 'togglePinScreen2',
-	clearPins = 'clear_Pins',
+	addPin = 'addPin',
+	unpin = 'unPin',
+	pin2 = 'pin2',
+	unPin2 = 'unPin2',
+	togglePin = 'togglePin',
+	togglePin2 = 'togglePin2',
+	clearPins = 'clearPin',
 }
 
 export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
@@ -76,7 +75,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 				}
 			},
 		},
-		[ActionIdUserPin.pinScreen2]: {
+		[ActionIdUserPin.pin2]: {
 			name: 'Pin Screen2',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
@@ -85,7 +84,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 				const command = createCommand(instance, '/pin2', userName, select.single)
 				if (command.isValidCommand) {
 					const sendToCommand = {
-						id: ActionIdUserPin.pinScreen2,
+						id: ActionIdUserPin.pin2,
 						options: {
 							command: command.oscPath,
 							args: command.args,
@@ -95,7 +94,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 				}
 			},
 		},
-		[ActionIdUserPin.unPinScreen2]: {
+		[ActionIdUserPin.unPin2]: {
 			name: 'Unpin Screen2',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
@@ -104,7 +103,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 				const command = createCommand(instance, '/unPin2', userName, select.single)
 				if (command.isValidCommand) {
 					const sendToCommand = {
-						id: ActionIdUserPin.unPinScreen2,
+						id: ActionIdUserPin.unPin2,
 						options: {
 							command: command.oscPath,
 							args: command.args,
@@ -112,22 +111,6 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 					}
 					sendActionCommand(instance, sendToCommand)
 				}
-			},
-		},
-		[ActionIdUserPin.clearPinsScreen2]: {
-			name: 'Clear PinsScreen2',
-			options: [],
-			callback: (): void => {
-				// type: 'Global'
-				const command = createCommand(instance, '/me/clearPin2')
-				const sendToCommand = {
-					id: ActionIdUserPin.clearPinsScreen2,
-					options: {
-						command: command.oscPath,
-						args: command.args,
-					},
-				}
-				sendActionCommand(instance, sendToCommand)
 			},
 		},
 		[ActionIdUserPin.togglePin]: {
@@ -149,7 +132,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 				}
 			},
 		},
-		[ActionIdUserPin.togglePinScreen2]: {
+		[ActionIdUserPin.togglePin2]: {
 			name: 'Toggle PinScreen2 (PRO)',
 			options: [options.userName],
 			callback: async (action): Promise<void> => {
@@ -158,7 +141,7 @@ export function GetActionsUserPin(instance: InstanceBaseExt<ZoomConfig>): {
 				const command = createCommand(instance, '/togglePin2', userName, select.single)
 				if (command.isValidCommand) {
 					const sendToCommand = {
-						id: ActionIdUserPin.togglePinScreen2,
+						id: ActionIdUserPin.togglePin2,
 						options: {
 							command: command.oscPath,
 							args: command.args,

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -788,6 +788,7 @@ export class OSC {
 					case 'meetingStatus': {
 						this.instance.log('info', 'meetingStatus receiving:' + JSON.stringify(data))
 						this.instance.ZoomClientDataObj.callStatus = data.args[0].value
+						const variables: CompanionVariableValues = {}
 						// Meeting status ended
 						if (data.args[0].value === 0 || data.args[0].value === 7) {
 							for (const key of Object.keys(this.instance.ZoomUserData)) {
@@ -812,12 +813,14 @@ export class OSC {
 
 							this.instance.ZoomUserData = {}
 							this.instance.InitVariables()
-							const variables: CompanionVariableValues = {}
 							updateCallStatusVariables(this.instance, variables)
 							updateAllUserBasedVariables(this.instance, variables)
 							this.instance.setVariableValues(variables)
 							// this.instance.UpdateVariablesValues()
 							this.instance.checkFeedbacks()
+						} else {
+							updateCallStatusVariables(this.instance, variables)
+							this.instance.setVariableValues(variables)
 						}
 						this.needToPingPong = true
 						break

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -672,7 +672,7 @@ export class OSC {
 						break
 					}
 					case 'pong': {
-						this.instance.log('debug', 'receiving pong')
+						// this.instance.log('debug', 'receiving pong')
 						// // {str zoomOSCversion}
 						// // {int subscribeMode}
 						// // {int galTrackMode}
@@ -786,7 +786,7 @@ export class OSC {
 					}
 					case 'meetingStatusChanged':
 					case 'meetingStatus': {
-						this.instance.log('info', 'meetingStatus receiving:' + JSON.stringify(data))
+						// this.instance.log('info', 'meetingStatus receiving:' + JSON.stringify(data))
 						this.instance.ZoomClientDataObj.callStatus = data.args[0].value
 						const variables: CompanionVariableValues = {}
 						// Meeting status ended

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -637,6 +637,11 @@ export class OSC {
 
 					case 'galleryOrder': {
 						// this.instance.log('debug', 'receiving:' + JSON.stringify(data))
+						// got empty gallery order array. Skip this
+						if (data.args.length === 0) {
+							return
+						}
+
 						this.instance.ZoomClientDataObj.galleryOrder.length = 0
 						data.args.forEach((order: { type: string; value: number }) => {
 							this.instance.ZoomClientDataObj.galleryOrder.push(order.value)
@@ -667,6 +672,7 @@ export class OSC {
 						break
 					}
 					case 'pong': {
+						this.instance.log('debug', 'receiving pong')
 						// // {str zoomOSCversion}
 						// // {int subscribeMode}
 						// // {int galTrackMode}
@@ -778,12 +784,20 @@ export class OSC {
 						}
 						break
 					}
+					case 'meetingStatusChanged':
 					case 'meetingStatus': {
-						// this.instance.log('info', 'meetingStatus receiving:' + JSON.stringify(data))
+						this.instance.log('info', 'meetingStatus receiving:' + JSON.stringify(data))
 						this.instance.ZoomClientDataObj.callStatus = data.args[0].value
 						// Meeting status ended
-						if (data.args[0].value === 0) {
+						if (data.args[0].value === 0 || data.args[0].value === 7) {
+							for (const key of Object.keys(this.instance.ZoomUserData)) {
+								if (parseInt(key) > this.instance.ZoomClientDataObj.numberOfGroups) {
+									delete this.instance.ZoomUserData[parseInt(key)]
+								}
+							}
+
 							this.instance.ZoomClientDataObj.selectedCallers.length = 0
+							this.instance.ZoomVariableLink.length = 0
 							this.instance.ZoomGroupData = []
 							for (let index = 0; index < this.instance.ZoomClientDataObj.numberOfGroups + 2; index++) {
 								this.instance.ZoomGroupData[index] = {
@@ -797,11 +811,13 @@ export class OSC {
 							// )
 
 							this.instance.ZoomUserData = {}
+							this.instance.InitVariables()
 							const variables: CompanionVariableValues = {}
 							updateCallStatusVariables(this.instance, variables)
 							updateAllUserBasedVariables(this.instance, variables)
 							this.instance.setVariableValues(variables)
 							// this.instance.UpdateVariablesValues()
+							this.instance.checkFeedbacks()
 						}
 						this.needToPingPong = true
 						break

--- a/src/presets/preset-pin-spotlight-view.ts
+++ b/src/presets/preset-pin-spotlight-view.ts
@@ -122,7 +122,7 @@ export function GetPresetsPinSpotlightViewActions(): CompanionPresetDefinitionsE
 			{
 				down: [
 					{
-						actionId: ActionIdUserPin.pinScreen2,
+						actionId: ActionIdUserPin.pin2,
 						options: {},
 					},
 				],
@@ -146,7 +146,7 @@ export function GetPresetsPinSpotlightViewActions(): CompanionPresetDefinitionsE
 			{
 				down: [
 					{
-						actionId: ActionIdUserPin.unPinScreen2,
+						actionId: ActionIdUserPin.unPin2,
 						options: {},
 					},
 				],
@@ -170,7 +170,7 @@ export function GetPresetsPinSpotlightViewActions(): CompanionPresetDefinitionsE
 			{
 				down: [
 					{
-						actionId: ActionIdUserPin.togglePinScreen2,
+						actionId: ActionIdUserPin.togglePin2,
 						options: {},
 					},
 				],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -338,6 +338,7 @@ export const options: Options = {
 		type: 'textinput',
 		label: 'Password(optional)',
 		id: 'password',
+		useVariables: true,
 		default: '',
 	},
 	zak: {

--- a/src/v2CommandsToUpgradeTov3.ts
+++ b/src/v2CommandsToUpgradeTov3.ts
@@ -78,17 +78,17 @@ export const v2Actions: v2Action = {
 	},
 	PinScreen2: {
 		oldActionId: 'PinScreen2',
-		newActionId: ActionIdUserPin.pinScreen2,
+		newActionId: ActionIdUserPin.pin2,
 		type: 'UserActions',
 	},
 	UnpinScreen2: {
 		oldActionId: 'UnpinScreen2',
-		newActionId: ActionIdUserPin.unPinScreen2,
+		newActionId: ActionIdUserPin.unPin2,
 		type: 'UserActions',
 	},
 	TogglePinScreen2: {
 		oldActionId: 'TogglePinScreen2',
-		newActionId: ActionIdUserPin.togglePinScreen2,
+		newActionId: ActionIdUserPin.togglePin2,
 		type: 'UserActions',
 	},
 	UnSpotlight: {
@@ -319,11 +319,6 @@ export const v2Actions: v2Action = {
 	TogglePin: {
 		oldActionId: 'TogglePin',
 		newActionId: ActionIdUserPin.togglePin,
-		type: 'GlobalActions',
-	},
-	ClearPinsScreen2: {
-		oldActionId: 'ClearPinsScreen2',
-		newActionId: ActionIdUserPin.clearPinsScreen2,
 		type: 'GlobalActions',
 	},
 	StartScreenShareWithPrimaryScreen: {

--- a/src/variables/variable-values.ts
+++ b/src/variables/variable-values.ts
@@ -236,7 +236,10 @@ export function updateCallStatusVariables(
 	instance: InstanceBaseExt<ZoomConfig>,
 	variables: CompanionVariableValues,
 ): void {
-	variables['callStatus'] = instance.ZoomClientDataObj.callStatus == 1 ? 'In meeting' : 'offline'
+	variables['callStatus'] =
+		instance.ZoomClientDataObj.callStatus === 0 || instance.ZoomClientDataObj.callStatus === 7
+			? 'offline'
+			: 'In meeting'
 }
 
 export function updateNumberOfUsers(instance: InstanceBaseExt<ZoomConfig>, variables: CompanionVariableValues): void {


### PR DESCRIPTION
fixes: #194 
fixes: #168 - note that this only works if the connection is not reset after the meeting has been joined.  they only send meeting status changed and not the meeting status.
fixes #195

fix the pin commands to match the documentation and actual commands.  Previously the commands didn't work the pin2 commands.