### PR TITLE
refactor: swap osc transport to node-osc

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
 	"dependencies": {
 		"@companion-module/base": "^1.12.1",
 		"@fast-csv/parse": "^5.0.5",
-		"@types/node-osc": "^10.0.0",
 		"got-cjs": "^12.5.4",
 		"node-osc": "^11.4.0"
 	},
@@ -35,6 +34,7 @@
 		"@types/got": "^9.6.12",
 		"@types/jest": "^30.0.0",
 		"@types/node": "^22.15.30",
+		"@types/node-osc": "^10.0.0",
 		"eslint": "^9.28.0",
 		"husky": "^9.1.7",
 		"jest": "^30.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
 	"dependencies": {
 		"@companion-module/base": "^1.12.1",
 		"@fast-csv/parse": "^5.0.5",
+		"@types/node-osc": "^10.0.0",
 		"got-cjs": "^12.5.4",
+		"node-osc": "^11.4.0",
 		"osc": "^2.4.5"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
 		"@fast-csv/parse": "^5.0.5",
 		"@types/node-osc": "^10.0.0",
 		"got-cjs": "^12.5.4",
-		"node-osc": "^11.4.0",
-		"osc": "^2.4.5"
+		"node-osc": "^11.4.0"
 	},
 	"devDependencies": {
 		"@companion-module/tools": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zoom-osc-iso",
-	"version": "4.11.1",
+	"version": "4.12.0",
 	"main": "dist/index.js",
 	"scripts": {
 		"postinstall": "husky",

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ class ZoomInstance extends InstanceBase<ZoomConfig> {
 				users: [],
 			}
 		}
-		if (this.OSC) this.OSC.destroy()
+		if (this.OSC) await this.OSC.destroy()
 		this.OSC = new OSC(this)
 		this.updateInstance()
 	}
@@ -155,7 +155,7 @@ class ZoomInstance extends InstanceBase<ZoomConfig> {
 		this.ZoomAudioLevelData = []
 		this.ZoomAudioRoutingData = []
 		this.log('debug', `Instance destroyed: ${this.id}`)
-		this.OSC?.destroy()
+		await this.OSC?.destroy()
 	}
 
 	/**

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -2,18 +2,34 @@ import { InstanceBaseExt, ZoomVersion } from './utils.js'
 import { InstanceStatus, OSCSomeArguments } from '@companion-module/base'
 import { ZoomConfig } from './config.js'
 import { FeedbackId } from './feedback.js'
-import { sendOscCommand, sendZoomIsoPullingCommands } from './osc/commands.js'
+import { normalizeNodeOscMessage, sendOscCommand, sendZoomIsoPullingCommands } from './osc/commands.js'
 import { dispatchOscMessage } from './osc/handlers/index.js'
 import { OSCHandlerContext, ZoomOSCResponse } from './osc/types.js'
 import { createZoomUser } from './osc/users.js'
-const osc = require('osc') // eslint-disable-line
+type NodeOscArgument = string | number | boolean | { type: string; value: string | number | boolean }
+type NodeOscMessage = [string, ...NodeOscArgument[]]
+type NodeOscClient = {
+	close(cb?: () => void): void
+	send(address: string, ...args: unknown[]): void
+}
+type NodeOscServer = {
+	close(cb?: () => void): void
+	on(event: 'message', listener: (message: NodeOscMessage) => void): NodeOscServer
+	on(event: 'error', listener: (error: { code?: string; message: string }) => void): NodeOscServer
+}
+type NodeOscModule = {
+	Client: new (host: string, port: number) => NodeOscClient
+	Server: new (port: number, host: string, cb?: () => void) => NodeOscServer
+}
+const nodeOsc = require('node-osc') as NodeOscModule // eslint-disable-line @typescript-eslint/no-require-imports
 
 export class OSC {
 	private readonly instance: InstanceBaseExt<ZoomConfig>
 	private oscHost = ''
 	private oscTXPort = 9090
 	private oscRXPort = 1234
-	private udpPort: any
+	private client: NodeOscClient | null = null
+	private server: NodeOscServer | null = null
 	private updateLoop = true
 	private firstLoop = true
 	private spotlightGroupTrackingInitalized = false
@@ -33,7 +49,10 @@ export class OSC {
 	 * @description Close connection on instance disable/removal
 	 */
 	public readonly destroy = (): void => {
-		if (this.udpPort) this.udpPort.close()
+		this.server?.close()
+		this.client?.close()
+		this.server = null
+		this.client = null
 		this.destroyTimers()
 		return
 	}
@@ -136,37 +155,24 @@ export class OSC {
 		this.oscRXPort = this.instance.config.rx_port || 1234
 
 		this.instance.updateStatus(InstanceStatus.Connecting)
-
-		this.udpPort = new osc.UDPPort({
-			localAddress: '0.0.0.0',
-			localPort: this.oscRXPort,
-			metadata: true,
-		})
-
-		// Listen for incoming OSC messages.
-		this.udpPort.on('message', (oscMsg: ZoomOSCResponse) => {
-			// this.instance.log('info', JSON.stringify(oscMsg))
-			// eslint-disable-next-line  @typescript-eslint/no-floating-promises
-			this.processData(oscMsg)
-		})
-
-		this.udpPort.on('error', (err: { code: string; message: string }) => {
-			if (err.code === 'EADDRINUSE') {
-				this.instance.log('error', 'Error: Selected port in use.' + err.message)
-			}
-		})
-
-		// Open the socket.
-		this.udpPort.open()
-
-		// When the port is ready
-		this.udpPort.on('ready', () => {
+		this.client = new nodeOsc.Client(this.oscHost, this.oscTXPort)
+		this.server = new nodeOsc.Server(this.oscRXPort, '0.0.0.0', () => {
 			this.instance.log('info', `Listening to ZoomOSC on port: ${this.oscRXPort}`)
 			this.instance.updateStatus(InstanceStatus.Connecting, 'Listening for first response')
-			// See if ZoomOSC is active
 			this.needToPingPong = true
 			this.createPingTimer()
 			this.createUpdatePresetsTimer()
+		})
+
+		this.server.on('message', (oscMsg) => {
+			// eslint-disable-next-line  @typescript-eslint/no-floating-promises
+			this.processData(normalizeNodeOscMessage(oscMsg) as ZoomOSCResponse)
+		})
+
+		this.server.on('error', (err: { code?: string; message: string }) => {
+			if (err.code === 'EADDRINUSE') {
+				this.instance.log('error', 'Error: Selected port in use.' + err.message)
+			}
 		})
 
 		return
@@ -236,7 +242,10 @@ export class OSC {
 	public readonly sendCommand = (path: string, args?: OSCSomeArguments): void => {
 		// this.instance.log('debug', `sending ${JSON.stringify(path)} ${args ? JSON.stringify(args) : ''}`)
 		try {
-			sendOscCommand(this.udpPort, this.oscHost, this.oscTXPort, path, args)
+			if (!this.client) {
+				throw new Error('OSC client is not connected')
+			}
+			sendOscCommand(this.client, path, args)
 		} catch (error) {
 			this.instance.log(
 				'error',

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -47,20 +47,18 @@ export class OSC {
 	 * @description Close connection on instance disable/removal
 	 */
 	public readonly destroy = async (): Promise<void> => {
-		const server = this.server
-		const client = this.client
+		this.destroyTimers()
 
-		if (server) {
-			await server.close()
+		if (this.server) {
+			await this.server.close()
 		}
 
-		if (client) {
-			await client.close()
+		if (this.client) {
+			await this.client.close()
 		}
 
 		this.server = null
 		this.client = null
-		this.destroyTimers()
 	}
 
 	public readonly destroyTimers = (): void => {

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -50,7 +50,13 @@ export class OSC {
 		const server = this.server
 		const client = this.client
 
-		await Promise.all([server?.close(), client?.close()])
+		if (server) {
+			await server.close()
+		}
+
+		if (client) {
+			await client.close()
+		}
 
 		this.server = null
 		this.client = null

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -21,6 +21,16 @@ type NodeOscModule = {
 }
 const nodeOsc = require('node-osc') as NodeOscModule // eslint-disable-line @typescript-eslint/no-require-imports
 
+async function closeNodeOscEndpoint(endpoint: NodeOscClient | NodeOscServer | null): Promise<void> {
+	if (!endpoint) {
+		return
+	}
+
+	await new Promise<void>((resolve) => {
+		endpoint.close(() => resolve())
+	})
+}
+
 export class OSC {
 	private readonly instance: InstanceBaseExt<ZoomConfig>
 	private oscHost = ''
@@ -46,13 +56,15 @@ export class OSC {
 	/**
 	 * @description Close connection on instance disable/removal
 	 */
-	public readonly destroy = (): void => {
-		this.server?.close()
-		this.client?.close()
+	public readonly destroy = async (): Promise<void> => {
+		const server = this.server
+		const client = this.client
+
+		await Promise.all([closeNodeOscEndpoint(server), closeNodeOscEndpoint(client)])
+
 		this.server = null
 		this.client = null
 		this.destroyTimers()
-		return
 	}
 
 	public readonly destroyTimers = (): void => {

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -4,10 +4,8 @@ import { ZoomConfig } from './config.js'
 import { FeedbackId } from './feedback.js'
 import { normalizeNodeOscMessage, sendOscCommand, sendZoomIsoPullingCommands } from './osc/commands.js'
 import { dispatchOscMessage } from './osc/handlers/index.js'
-import { OSCHandlerContext, ZoomOSCResponse } from './osc/types.js'
+import { NodeOscMessage, OSCHandlerContext, ZoomOSCResponse } from './osc/types.js'
 import { createZoomUser } from './osc/users.js'
-type NodeOscArgument = string | number | boolean | { type: string; value: string | number | boolean }
-type NodeOscMessage = [string, ...NodeOscArgument[]]
 type NodeOscClient = {
 	close(cb?: () => void): void
 	send(address: string, ...args: unknown[]): void
@@ -166,7 +164,7 @@ export class OSC {
 
 		this.server.on('message', (oscMsg) => {
 			// eslint-disable-next-line  @typescript-eslint/no-floating-promises
-			this.processData(normalizeNodeOscMessage(oscMsg) as ZoomOSCResponse)
+			this.processData(normalizeNodeOscMessage(oscMsg))
 		})
 
 		this.server.on('error', (err: { code?: string; message: string }) => {

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -7,11 +7,11 @@ import { dispatchOscMessage } from './osc/handlers/index.js'
 import { NodeOscMessage, OSCHandlerContext, ZoomOSCResponse } from './osc/types.js'
 import { createZoomUser } from './osc/users.js'
 type NodeOscClient = {
-	close(cb?: () => void): void
+	close(): Promise<void>
 	send(address: string, ...args: unknown[]): void
 }
 type NodeOscServer = {
-	close(cb?: () => void): void
+	close(): Promise<void>
 	on(event: 'message', listener: (message: NodeOscMessage) => void): NodeOscServer
 	on(event: 'error', listener: (error: { code?: string; message: string }) => void): NodeOscServer
 }
@@ -20,16 +20,6 @@ type NodeOscModule = {
 	Server: new (port: number, host: string, cb?: () => void) => NodeOscServer
 }
 const nodeOsc = require('node-osc') as NodeOscModule // eslint-disable-line @typescript-eslint/no-require-imports
-
-async function closeNodeOscEndpoint(endpoint: NodeOscClient | NodeOscServer | null): Promise<void> {
-	if (!endpoint) {
-		return
-	}
-
-	await new Promise<void>((resolve) => {
-		endpoint.close(() => resolve())
-	})
-}
 
 export class OSC {
 	private readonly instance: InstanceBaseExt<ZoomConfig>
@@ -60,7 +50,7 @@ export class OSC {
 		const server = this.server
 		const client = this.client
 
-		await Promise.all([closeNodeOscEndpoint(server), closeNodeOscEndpoint(client)])
+		await Promise.all([server?.close(), client?.close()])
 
 		this.server = null
 		this.client = null

--- a/src/osc/commands.ts
+++ b/src/osc/commands.ts
@@ -2,14 +2,13 @@ import type { OSCSomeArguments } from '@companion-module/base'
 import type { ZoomConfig } from '../config.js'
 import type { OSCArgument, OSCMetaArgument } from '@companion-module/base'
 import { SubscribeMode } from '../utils.js'
+import type { NodeOscArgument, NodeOscMessage, ZoomOSCResponse } from './types.js'
 
 type SendCommand = (path: string, args?: OSCSomeArguments) => void
 type OSCClientSender = {
 	send(address: string, ...args: Array<OSCArgument | OSCMetaArgument>): void
 }
 
-type NodeOscArgument = string | number | boolean | { type: string; value: string | number | boolean }
-type NodeOscMessage = [string, ...NodeOscArgument[]]
 type OscArgumentArray = Array<OSCArgument | OSCMetaArgument>
 
 function toArgumentArray(args?: OSCSomeArguments): OscArgumentArray {
@@ -37,7 +36,7 @@ export function sendZoomIsoPullingCommands(sendCommand: SendCommand, config: Zoo
 	if (config.pollAudioRouting) sendCommand('/zoom/getAudioRouting', [])
 }
 
-export function normalizeNodeOscMessage(message: NodeOscMessage): { address: string; args: OSCMetaArgument[] } {
+export function normalizeNodeOscMessage(message: NodeOscMessage): ZoomOSCResponse {
 	const [address, ...args] = message
 
 	return {

--- a/src/osc/commands.ts
+++ b/src/osc/commands.ts
@@ -1,27 +1,27 @@
 import type { OSCSomeArguments } from '@companion-module/base'
 import type { ZoomConfig } from '../config.js'
+import type { OSCArgument, OSCMetaArgument } from '@companion-module/base'
 import { SubscribeMode } from '../utils.js'
 
 type SendCommand = (path: string, args?: OSCSomeArguments) => void
-type OSCPortSender = {
-	send(message: { address: string; args: OSCSomeArguments }, oscHost: string, oscTXPort: number): void
+type OSCClientSender = {
+	send(address: string, ...args: Array<OSCArgument | OSCMetaArgument>): void
 }
 
-export function sendOscCommand(
-	udpPort: OSCPortSender,
-	oscHost: string,
-	oscTXPort: number,
-	path: string,
-	args?: OSCSomeArguments,
-): void {
-	udpPort.send(
-		{
-			address: path,
-			args: args ?? [],
-		},
-		oscHost,
-		oscTXPort,
-	)
+type NodeOscArgument = string | number | boolean | { type: string; value: string | number | boolean }
+type NodeOscMessage = [string, ...NodeOscArgument[]]
+type OscArgumentArray = Array<OSCArgument | OSCMetaArgument>
+
+function toArgumentArray(args?: OSCSomeArguments): OscArgumentArray {
+	if (args === undefined) {
+		return []
+	}
+
+	return Array.isArray(args) ? args : [args]
+}
+
+export function sendOscCommand(client: OSCClientSender, path: string, args?: OSCSomeArguments): void {
+	client.send(path, ...toArgumentArray(args))
 }
 
 export function sendZoomSubscriptions(sendCommand: SendCommand): void {
@@ -35,4 +35,36 @@ export function sendZoomIsoPullingCommands(sendCommand: SendCommand, config: Zoo
 	if (config.pollAudioLevels) sendCommand('/zoom/getAudioLevels', [])
 	if (config.pollOutputRouting) sendCommand('/zoom/getOutputRouting', [])
 	if (config.pollAudioRouting) sendCommand('/zoom/getAudioRouting', [])
+}
+
+export function normalizeNodeOscMessage(message: NodeOscMessage): { address: string; args: OSCMetaArgument[] } {
+	const [address, ...args] = message
+
+	return {
+		address,
+		args: args.map(toMetaArgument),
+	}
+}
+
+function toMetaArgument(arg: NodeOscArgument): OSCMetaArgument {
+	if (typeof arg === 'object' && arg !== null && 'type' in arg && 'value' in arg) {
+		if (arg.type === 's') {
+			return { type: 's', value: String(arg.value) }
+		}
+
+		return {
+			type: arg.type === 'f' ? 'f' : 'i',
+			value: typeof arg.value === 'number' ? arg.value : Number(arg.value),
+		}
+	}
+
+	if (typeof arg === 'string') {
+		return { type: 's', value: arg }
+	}
+
+	if (typeof arg === 'boolean') {
+		return { type: 'i', value: arg ? 1 : 0 }
+	}
+
+	return { type: Number.isInteger(arg) ? 'i' : 'f', value: arg }
 }

--- a/src/osc/commands.ts
+++ b/src/osc/commands.ts
@@ -1,6 +1,5 @@
-import type { OSCSomeArguments } from '@companion-module/base'
+import type { OSCSomeArguments, OSCArgument, OSCMetaArgument } from '@companion-module/base'
 import type { ZoomConfig } from '../config.js'
-import type { OSCArgument, OSCMetaArgument } from '@companion-module/base'
 import { SubscribeMode } from '../utils.js'
 import type { NodeOscArgument, NodeOscMessage, ZoomOSCResponse } from './types.js'
 

--- a/src/osc/types.ts
+++ b/src/osc/types.ts
@@ -12,6 +12,14 @@ export interface ZoomOSCResponse {
 	args: ZoomOSCArgument[]
 }
 
+export type NodeOscTypedArgument = {
+	type: string
+	value: string | number | boolean
+}
+
+export type NodeOscArgument = string | number | boolean | NodeOscTypedArgument
+export type NodeOscMessage = [string, ...NodeOscArgument[]]
+
 export enum UserRole {
 	Host = 1,
 	CoHost = 2,

--- a/tests/osc/commands.test.ts
+++ b/tests/osc/commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals'
-import { sendZoomIsoPullingCommands } from '../../src/osc/commands.js'
+import { normalizeNodeOscMessage, sendZoomIsoPullingCommands } from '../../src/osc/commands.js'
 import type { ZoomConfig } from '../../src/config.js'
 
 function createConfig(overrides: Partial<ZoomConfig> = {}): ZoomConfig {
@@ -43,5 +43,40 @@ describe('sendZoomIsoPullingCommands', () => {
 		expect(sendCommand).toHaveBeenCalledTimes(2)
 		expect(sendCommand).toHaveBeenNthCalledWith(1, '/zoom/getEngineState', [])
 		expect(sendCommand).toHaveBeenNthCalledWith(2, '/zoom/getOutputRouting', [])
+	})
+})
+
+describe('normalizeNodeOscMessage', () => {
+	it('normalizes string, integer, float, and boolean arguments', () => {
+		expect(normalizeNodeOscMessage(['/zoom/test', 'hello', 4, 1.5, true, false])).toEqual({
+			address: '/zoom/test',
+			args: [
+				{ type: 's', value: 'hello' },
+				{ type: 'i', value: 4 },
+				{ type: 'f', value: 1.5 },
+				{ type: 'i', value: 1 },
+				{ type: 'i', value: 0 },
+			],
+		})
+	})
+
+	it('normalizes typed node-osc arguments into OSC meta arguments', () => {
+		expect(
+			normalizeNodeOscMessage([
+				'/zoom/typed',
+				{ type: 's', value: 12 },
+				{ type: 'f', value: '2.25' },
+				{ type: 'i', value: '7' },
+				{ type: 'b', value: true },
+			]),
+		).toEqual({
+			address: '/zoom/typed',
+			args: [
+				{ type: 's', value: '12' },
+				{ type: 'f', value: 2.25 },
+				{ type: 'i', value: 7 },
+				{ type: 'i', value: 1 },
+			],
+		})
 	})
 })

--- a/tests/osc/commands.test.ts
+++ b/tests/osc/commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals'
-import { normalizeNodeOscMessage, sendZoomIsoPullingCommands } from '../../src/osc/commands.js'
+import type { OSCSomeArguments } from '@companion-module/base'
+import { normalizeNodeOscMessage, sendOscCommand, sendZoomIsoPullingCommands } from '../../src/osc/commands.js'
 import type { ZoomConfig } from '../../src/config.js'
 
 function createConfig(overrides: Partial<ZoomConfig> = {}): ZoomConfig {
@@ -43,6 +44,38 @@ describe('sendZoomIsoPullingCommands', () => {
 		expect(sendCommand).toHaveBeenCalledTimes(2)
 		expect(sendCommand).toHaveBeenNthCalledWith(1, '/zoom/getEngineState', [])
 		expect(sendCommand).toHaveBeenNthCalledWith(2, '/zoom/getOutputRouting', [])
+	})
+})
+
+describe('sendOscCommand', () => {
+	it('sends no arguments when args is undefined', () => {
+		const client = { send: jest.fn() }
+
+		sendOscCommand(client, '/zoom/ping')
+
+		expect(client.send).toHaveBeenCalledWith('/zoom/ping')
+	})
+
+	it('preserves empty arrays and scalar OSC arguments', () => {
+		const client = { send: jest.fn() }
+
+		sendOscCommand(client, '/zoom/empty', [])
+		sendOscCommand(client, '/zoom/scalar', { type: 'i', value: 7 })
+
+		expect(client.send).toHaveBeenNthCalledWith(1, '/zoom/empty')
+		expect(client.send).toHaveBeenNthCalledWith(2, '/zoom/scalar', { type: 'i', value: 7 })
+	})
+
+	it('spreads OSC argument arrays into node-osc varargs', () => {
+		const client = { send: jest.fn() }
+		const args: OSCSomeArguments = [
+			{ type: 's', value: 'hello' },
+			{ type: 'i', value: 2 },
+		]
+
+		sendOscCommand(client, '/zoom/mixed', args)
+
+		expect(client.send).toHaveBeenCalledWith('/zoom/mixed', ...args)
 	})
 })
 

--- a/tests/osc/osc.test.ts
+++ b/tests/osc/osc.test.ts
@@ -2,8 +2,6 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { OSC } from '../../src/osc.js'
 import { createMockInstance } from '../helpers/mock-instance.js'
 
-type CloseCallback = (() => void) | undefined
-
 const nodeOscMock = jest.requireMock('node-osc') as {
 	Client: jest.Mock
 	Server: jest.Mock
@@ -15,24 +13,26 @@ describe('OSC destroy', () => {
 		nodeOscMock.Server.mockReset()
 	})
 
-	it('waits for node-osc close callbacks before resolving destroy', async () => {
-		let serverCloseCallback: CloseCallback
-		let clientCloseCallback: CloseCallback
+	it('waits for node-osc close promises before resolving destroy', async () => {
+		let resolveServerClose!: () => void
+		let resolveClientClose!: () => void
+		const serverClosePromise = new Promise<void>((resolve) => {
+			resolveServerClose = resolve
+		})
+		const clientClosePromise = new Promise<void>((resolve) => {
+			resolveClientClose = resolve
+		})
 
 		nodeOscMock.Client.mockImplementation(() => ({
 			send: jest.fn(),
-			close: jest.fn((callback?: () => void) => {
-				clientCloseCallback = callback
-			}),
+			close: jest.fn(async () => clientClosePromise),
 		}))
 		nodeOscMock.Server.mockImplementation((...args: unknown[]) => {
 			const ready = args[2] as (() => void) | undefined
 			ready?.()
 			return {
 				on: jest.fn().mockReturnThis(),
-				close: jest.fn((callback?: () => void) => {
-					serverCloseCallback = callback
-				}),
+				close: jest.fn(async () => serverClosePromise),
 			}
 		})
 
@@ -46,11 +46,11 @@ describe('OSC destroy', () => {
 		await Promise.resolve()
 		expect(resolved).toBe(false)
 
-		serverCloseCallback?.()
+		resolveServerClose()
 		await Promise.resolve()
 		expect(resolved).toBe(false)
 
-		clientCloseCallback?.()
+		resolveClientClose()
 		await destroyPromise
 		expect(resolved).toBe(true)
 	})

--- a/tests/osc/osc.test.ts
+++ b/tests/osc/osc.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { OSC } from '../../src/osc.js'
+import { createMockInstance } from '../helpers/mock-instance.js'
+
+type CloseCallback = (() => void) | undefined
+
+const nodeOscMock = jest.requireMock('node-osc') as {
+	Client: jest.Mock
+	Server: jest.Mock
+}
+
+describe('OSC destroy', () => {
+	beforeEach(() => {
+		nodeOscMock.Client.mockReset()
+		nodeOscMock.Server.mockReset()
+	})
+
+	it('waits for node-osc close callbacks before resolving destroy', async () => {
+		let serverCloseCallback: CloseCallback
+		let clientCloseCallback: CloseCallback
+
+		nodeOscMock.Client.mockImplementation(() => ({
+			send: jest.fn(),
+			close: jest.fn((callback?: () => void) => {
+				clientCloseCallback = callback
+			}),
+		}))
+		nodeOscMock.Server.mockImplementation((...args: unknown[]) => {
+			const ready = args[2] as (() => void) | undefined
+			ready?.()
+			return {
+				on: jest.fn().mockReturnThis(),
+				close: jest.fn((callback?: () => void) => {
+					serverCloseCallback = callback
+				}),
+			}
+		})
+
+		const osc = new OSC(createMockInstance())
+		const destroyPromise = osc.destroy()
+		let resolved = false
+		void destroyPromise.then(() => {
+			resolved = true
+		})
+
+		await Promise.resolve()
+		expect(resolved).toBe(false)
+
+		serverCloseCallback?.()
+		await Promise.resolve()
+		expect(resolved).toBe(false)
+
+		clientCloseCallback?.()
+		await destroyPromise
+		expect(resolved).toBe(true)
+	})
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,15 +1,17 @@
 /**
  * Global test setup — runs after Jest framework is installed.
  *
- * Safety-net Layer 2: prevents the `osc` UDP library from opening real sockets
+ * Safety-net Layer 2: prevents the OSC transport library from opening real sockets
  * if osc.ts is accidentally imported. Primary protection is the mock instance
  * (instance.OSC = { sendCommand: jest.fn() }) in mock-instance.ts.
  */
-jest.mock('osc', () => ({
-	UDPPort: jest.fn().mockImplementation(() => ({
+jest.mock('node-osc', () => ({
+	Client: jest.fn().mockImplementation(() => ({
 		send: jest.fn(),
+		close: jest.fn(),
+	})),
+	Server: jest.fn().mockImplementation(() => ({
 		on: jest.fn(),
-		open: jest.fn(),
 		close: jest.fn(),
 	})),
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,6 +1437,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-osc@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@types/node-osc@npm:10.0.0"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/8f9dfa2712a38eadc8a249c09d50fcd70f6e947377a18d345e61575cf4bd854a92a19e94416fe8198259cbe9353903ccd3798a4cf573c08a6d56a1291f1cc49e
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:^22.15.30":
   version: 22.15.30
   resolution: "@types/node@npm:22.15.30"
@@ -5202,6 +5211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-osc@npm:^11.4.0":
+  version: 11.4.0
+  resolution: "node-osc@npm:11.4.0"
+  checksum: 10c0/e9911909373df94f05196e1049887fca0a6f27408b0d5a6d848a4da968fc0284483bc33154c62176749b21934627961802688310aafe0a5cafc8d8ed4087a721
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.27":
   version: 2.0.27
   resolution: "node-releases@npm:2.0.27"
@@ -6934,11 +6950,13 @@ __metadata:
     "@types/got": "npm:^9.6.12"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.15.30"
+    "@types/node-osc": "npm:^10.0.0"
     eslint: "npm:^9.28.0"
     got-cjs: "npm:^12.5.4"
     husky: "npm:^9.1.7"
     jest: "npm:^30.2.0"
     lint-staged: "npm:^15.5.2"
+    node-osc: "npm:^11.4.0"
     osc: "npm:^2.4.5"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,135 +1109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@serialport/binding-mock@npm:10.2.2":
-  version: 10.2.2
-  resolution: "@serialport/binding-mock@npm:10.2.2"
-  dependencies:
-    "@serialport/bindings-interface": "npm:^1.2.1"
-    debug: "npm:^4.3.3"
-  checksum: 10c0/ba0b26f0e449b32b77315cf57d377318d4ffdaa84d6aaa1efdc48f35b99ade513d2a37f672443163446f1feeb664d5d518f05ea5c5c90d935b87a92fee36b2ba
-  languageName: node
-  linkType: hard
-
-"@serialport/bindings-cpp@npm:12.0.1":
-  version: 12.0.1
-  resolution: "@serialport/bindings-cpp@npm:12.0.1"
-  dependencies:
-    "@serialport/bindings-interface": "npm:1.2.2"
-    "@serialport/parser-readline": "npm:11.0.0"
-    debug: "npm:4.3.4"
-    node-addon-api: "npm:7.0.0"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:4.6.0"
-  checksum: 10c0/cd64221e8b5a612cf6916843b56e6c5aacdc16d2de4c123354638466c9f57155db77152351a344a8f7e0c25279bfdb30c44a5ed77c00cdaa0a7b782b25e042e0
-  languageName: node
-  linkType: hard
-
-"@serialport/bindings-interface@npm:1.2.2, @serialport/bindings-interface@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "@serialport/bindings-interface@npm:1.2.2"
-  checksum: 10c0/e0fb8deaee585573c4151dcb13cc2dc471fc9906a16d8b595fd9aed27e263b8b2e1ba94b0eda814f2ddab7d4143ad7d504b5d2034e5607d8c1d77b4b3dcfc369
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-byte-length@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-byte-length@npm:12.0.0"
-  checksum: 10c0/8dbc2515c83c9ecbaa1f6fbd20c04a13d49f440e4cbcf248a67c728ff28643fca24cea749f12b12231ce14397be124cd893eb2b21ced551982acb795b7a09398
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-cctalk@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-cctalk@npm:12.0.0"
-  checksum: 10c0/9abf7342f9199feb3c222269bb8f47e7a722c747242df32529dc94dabe4e9caf591b0827caaf82ef5143aaf6103e63e9ec2f5f3e28657f08040991cdd67825ee
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-delimiter@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@serialport/parser-delimiter@npm:11.0.0"
-  checksum: 10c0/59ddd9603396e40f145e8087050596fa02b0e64f52972f328a54b3260b0582c7b4107dbbb0fb8db2f9ea6d0db72237c6a262992649f1e2aa706924a490079380
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-delimiter@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-delimiter@npm:12.0.0"
-  checksum: 10c0/b7c558cd300d7a137b9cf5eb7617d2598fa2cdc2f9feefea79667a6fef37f36aa08c7c7849413f361802801acfd2a81a4fe13fe6672801a65b5ee5e1d5625578
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-inter-byte-timeout@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-inter-byte-timeout@npm:12.0.0"
-  checksum: 10c0/a6454d96310c471fd99cb613b7e4dd3bb26aa32036f739ac584491c2bbbb9cf15e3799e6d129dc74e0db008df209c06002b7b344d66d7aae251ae78547040fc1
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-packet-length@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-packet-length@npm:12.0.0"
-  checksum: 10c0/2f1a8b22d6e4af4c42f8dcab0edf4bece4b879b75fb703d77ea2dbaf0ecf61ac0ed943529c33cfb74f77257cd07991337b6eaade16be782713836dc664982647
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-readline@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@serialport/parser-readline@npm:11.0.0"
-  dependencies:
-    "@serialport/parser-delimiter": "npm:11.0.0"
-  checksum: 10c0/20cf031cd6abef27721303444c1348fcc4bd1976a4557810c4b57ccc356a84cb7de6351613fe2a54eef20030ca23b345fc1077dcdf979548bca9483cf45ad5d5
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-readline@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-readline@npm:12.0.0"
-  dependencies:
-    "@serialport/parser-delimiter": "npm:12.0.0"
-  checksum: 10c0/765b8e89f40c2e3e4516027009ac65fc01f475dc2d111a4d50bdeac2fd5a9653e9222c9cce3abd305d45d555ec9c6a8764b38cf214a90be6073751d6456889e4
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-ready@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-ready@npm:12.0.0"
-  checksum: 10c0/6fcfb505c3eebaf50d9df7b27934b217dac626f08a0446393ae2d575ffa41deefc8c27cfd46dd079add215c859616127e69f1f1aff2a6905aaaa9609d11b269e
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-regex@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-regex@npm:12.0.0"
-  checksum: 10c0/6ec242235bf67a9c359b1164a553ee4ad683519326c989a88b499b8a872ce07a843556b2d1efe7d091bf3976c8b2458c399dd1c57efeee4d0ba49291365eda30
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-slip-encoder@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-slip-encoder@npm:12.0.0"
-  checksum: 10c0/e1619a79d175f208d6e808920fb8fe011405e0d544459088d461be497b8a4933b47db8e6e4133f3b16562f563216c312d1e8f37c8629dcca8221ee39b7049e37
-  languageName: node
-  linkType: hard
-
-"@serialport/parser-spacepacket@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/parser-spacepacket@npm:12.0.0"
-  checksum: 10c0/e4ee26dc00f16abd1e7b17f999a0e335c6b963c8f00083bf11c8feb8baad891602dca91a614e4d12f7b3805e1cf829ea497aca022b8f0e02b8cad235e21955ef
-  languageName: node
-  linkType: hard
-
-"@serialport/stream@npm:12.0.0":
-  version: 12.0.0
-  resolution: "@serialport/stream@npm:12.0.0"
-  dependencies:
-    "@serialport/bindings-interface": "npm:1.2.2"
-    debug: "npm:4.3.4"
-  checksum: 10c0/5edd07425c8801f8ea50d1601663a4c39eb67cc984c0898b8176aa7e86f76ffe4400da7ff624f222182a66f87694c2915ecb416113b038a0e5ce82306308ef6e
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.34.0":
   version: 0.34.49
   resolution: "@sinclair/typebox@npm:0.34.49"
@@ -2659,7 +2530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.4.0":
+"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0":
   version: 4.4.1
   resolution: "debug@npm:4.4.1"
   dependencies:
@@ -2668,18 +2539,6 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/d2b44bc1afd912b49bb7ebb0d50a860dc93a4dd7d946e8de94abc957bb63726b7dd5aa48c18c2386c379ec024c46692e15ed3ed97d481729f929201e671fcd55
-  languageName: node
-  linkType: hard
-
-"debug@npm:4.3.4":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
-  dependencies:
-    ms: "npm:2.1.2"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/cedbec45298dd5c501d01b92b119cd3faebe5438c3917ff11ae1bff86a6c722930ac9c8659792824013168ba6db7c4668225d845c633fbdafbbf902a6389f736
   languageName: node
   linkType: hard
 
@@ -4822,13 +4681,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:4.0.0":
-  version: 4.0.0
-  resolution: "long@npm:4.0.0"
-  checksum: 10c0/50a6417d15b06104dbe4e3d4a667c39b137f130a9108ea8752b352a4cfae047531a3ac351c181792f3f8768fe17cca6b0f406674a541a86fb638aaac560d83ed
-  languageName: node
-  linkType: hard
-
 "lowercase-keys@npm:2.0.0, lowercase-keys@npm:^2.0.0":
   version: 2.0.0
   resolution: "lowercase-keys@npm:2.0.0"
@@ -5111,13 +4963,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.2":
-  version: 2.1.2
-  resolution: "ms@npm:2.1.2"
-  checksum: 10c0/a437714e2f90dbf881b5191d35a6db792efbca5badf112f87b9e1c712aace4b4b9b742dd6537f3edf90fd6f684de897cec230abde57e87883766712ddda297cc
-  languageName: node
-  linkType: hard
-
 "ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -5161,26 +5006,6 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:7.0.0":
-  version: 7.0.0
-  resolution: "node-addon-api@npm:7.0.0"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/3d5a15ee434e122b345e614db122a63f30194c298104c3d8a0fa9f68707abb278af27b45222602456a131890a59b4a92291ff5b4b7938ff282168e9ad1bf7103
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:4.6.0":
-  version: 4.6.0
-  resolution: "node-gyp-build@npm:4.6.0"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10c0/147add65942acd3cf641d11d9becd030128c7298a5b4aec4ebf3ad4afcc3d0298ad2562afba3e7b2bf70160c5e2e82235e3bc043ff9c52dc68bdd36c856764fe
   languageName: node
   linkType: hard
 
@@ -5322,22 +5147,6 @@ __metadata:
     type-check: "npm:^0.4.0"
     word-wrap: "npm:^1.2.5"
   checksum: 10c0/4afb687a059ee65b61df74dfe87d8d6815cd6883cb8b3d5883a910df72d0f5d029821f37025e4bccf4048873dbdb09acc6d303d27b8f76b1a80dd5a7d5334675
-  languageName: node
-  linkType: hard
-
-"osc@npm:^2.4.5":
-  version: 2.4.5
-  resolution: "osc@npm:2.4.5"
-  dependencies:
-    long: "npm:4.0.0"
-    serialport: "npm:12.0.0"
-    slip: "npm:1.0.2"
-    wolfy87-eventemitter: "npm:5.2.9"
-    ws: "npm:8.18.0"
-  dependenciesMeta:
-    serialport:
-      optional: true
-  checksum: 10c0/745be9a71bb2d784046b08db5a255634835851c635d3ed97c26949b823b970ded55efc0a832a706e488ee3829ea17a0edbce8eb002223cbe0bc30c5d4f701e84
   languageName: node
   linkType: hard
 
@@ -5917,28 +5726,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialport@npm:12.0.0":
-  version: 12.0.0
-  resolution: "serialport@npm:12.0.0"
-  dependencies:
-    "@serialport/binding-mock": "npm:10.2.2"
-    "@serialport/bindings-cpp": "npm:12.0.1"
-    "@serialport/parser-byte-length": "npm:12.0.0"
-    "@serialport/parser-cctalk": "npm:12.0.0"
-    "@serialport/parser-delimiter": "npm:12.0.0"
-    "@serialport/parser-inter-byte-timeout": "npm:12.0.0"
-    "@serialport/parser-packet-length": "npm:12.0.0"
-    "@serialport/parser-readline": "npm:12.0.0"
-    "@serialport/parser-ready": "npm:12.0.0"
-    "@serialport/parser-regex": "npm:12.0.0"
-    "@serialport/parser-slip-encoder": "npm:12.0.0"
-    "@serialport/parser-spacepacket": "npm:12.0.0"
-    "@serialport/stream": "npm:12.0.0"
-    debug: "npm:4.3.4"
-  checksum: 10c0/ad282898055947dd89ebb7ac7433d2961b0bba311a1c7009f2eda1aac9bfd5b1f59e50b30df8e1d3c20c323f05aefd134028bdab1b8f9dde3cbc46b32e9b8765
-  languageName: node
-  linkType: hard
-
 "shallow-clone@npm:^3.0.0":
   version: 3.0.1
   resolution: "shallow-clone@npm:3.0.1"
@@ -6002,13 +5789,6 @@ __metadata:
     ansi-styles: "npm:^6.2.1"
     is-fullwidth-code-point: "npm:^5.0.0"
   checksum: 10c0/631c971d4abf56cf880f034d43fcc44ff883624867bf11ecbd538c47343911d734a4656d7bc02362b40b89d765652a7f935595441e519b59e2ad3f4d5d6fe7ca
-  languageName: node
-  linkType: hard
-
-"slip@npm:1.0.2":
-  version: 1.0.2
-  resolution: "slip@npm:1.0.2"
-  checksum: 10c0/f1a235ec2960c9c769c149dd6f0c21b74c7abf7f1f8b249cbe1370bae75e20f60faee25b4a951407cedd355ebab17038323f5fc800f6bab188877472566fe81a
   languageName: node
   linkType: hard
 
@@ -6774,13 +6554,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wolfy87-eventemitter@npm:5.2.9":
-  version: 5.2.9
-  resolution: "wolfy87-eventemitter@npm:5.2.9"
-  checksum: 10c0/dd218e3eb5fe2bbb7894d19b857ee7df1b711cadb6dfa177392d42b71522979d1883489057d13cf7af6785835b9807ab1f821d3dbf79ee9691ba27e72ad91c4d
-  languageName: node
-  linkType: hard
-
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -6842,21 +6615,6 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/e8c850a8e3e74eeadadb8ad23c9d9d63e4e792bd10f4836ed74189ef6e996763959f1249c5650e232f3c77c11169d239cbfc8342fc70f3fe401407d23810505d
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.18.0":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
   languageName: node
   linkType: hard
 
@@ -6957,7 +6715,6 @@ __metadata:
     jest: "npm:^30.2.0"
     lint-staged: "npm:^15.5.2"
     node-osc: "npm:^11.4.0"
-    osc: "npm:^2.4.5"
     prettier: "npm:^3.5.3"
     rimraf: "npm:^6.0.1"
     ts-jest: "npm:^29.4.6"


### PR DESCRIPTION
## Summary
- swap the Phase 0 OSC transport from `osc` to `node-osc` while preserving the refactored handler architecture and the merged Phase 0 bugfix behavior
- remove the legacy `osc` dependency, keep the `node-osc` type package in `devDependencies`, and tighten the transport boundary with shared node-osc payload types, direct normalization coverage, and the simpler upstream-style async transport teardown
- keep the branch aligned with merged Phase 0 so the transport swap is isolated for manual verification before the Companion v2 work lands

## Included commits
- `f37326d` refactor: swap osc transport to node-osc
- `9628102` chore: remove legacy osc dependency
- `15f654b` chore: move node-osc types to dev dependencies
- `5ad45b1` refactor: share node-osc transport types
- `fcca84b` test: cover node-osc message normalization
- `ad15bf9` fix: simplify node-osc teardown awaits
- `d4c9719` refactor: simplify osc destroy awaits
- `1c4159f` chore: bump version to 4.12.0

## Validation
- `yarn install`
- `yarn build`
- `yarn lint`
- `yarn test --runInBand`
- `yarn test --runInBand --coverage --collectCoverageFrom=src/osc/commands.ts --collectCoverageFrom=src/osc.ts --collectCoverageFrom=src/index.ts tests/osc/commands.test.ts tests/osc/osc.test.ts`
